### PR TITLE
chore(cmd): refactor commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,6 @@ jobs:
       - uses: go-semantic-release/action@v1
         with:
           hooks: goreleaser
-          prerelease: false
           changelog-file: CHANGELOG.md
           changelog-generator-opt: "emojis=true"
         env:

--- a/cmd/coco/commands/dependencies.go
+++ b/cmd/coco/commands/dependencies.go
@@ -10,7 +10,6 @@ import (
 	"github.com/SAP/configuration-tools-for-gitops/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
 )
 
 const (
@@ -18,17 +17,18 @@ const (
 )
 
 var (
-	dependencyFile, outputFile, sourceBranch, targetBranch, rawFormat string
+	outputFile, sourceBranch, targetBranch, rawFormat string
 
 	format     graph.OutputFormat
 	graphDepth int
 )
 
-var dependenciesCmd = &cobra.Command{
-	Use:     "dependencies",
-	Aliases: []string{"deps"},
-	Short:   "Returns structured information which components and dependencies are affected by a change in git",
-	Long: `The dependencies command finds all components and their downstream dependencies
+func newDependencies() *cobra.Command {
+	var c = &cobra.Command{
+		Use:     "dependencies",
+		Aliases: []string{"deps"},
+		Short:   "Returns structured information which components and dependencies are affected by a change in git",
+		Long: `The dependencies command finds all components and their downstream dependencies
 	that are affected by a change from a source to a target commit.
 	This is done by constructing the full dependency graph of upstream components
 	(defined implicitly via the direct upstream dependencies given in the 
@@ -36,101 +36,78 @@ var dependenciesCmd = &cobra.Command{
 	In addition all components that have changed between the source and the target
 	commit are identified. Combining the dependency graph and the changed components
 	gives the complete structure of change-affected components.`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		return nil
-	},
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if viper.GetString("git-token") == "" {
-			cobra.CheckErr(
-				"environment variable \"GITHUB_TOKEN\" must be set for the \"dependencies\" command.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if viper.GetString("git-token") == "" {
+				cobra.CheckErr(
+					"environment variable \"GITHUB_TOKEN\" must be set for the \"dependencies\" command.",
+				)
+			}
+			var ok bool
+			format, ok = graph.CastOutputFormat(rawFormat)
+			if !ok {
+				log.Sugar.Errorf("illegal format %q", rawFormat)
+				os.Exit(1)
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			changedDeps, err := dependencies.ChangeAffectedComponents(
+				viper.GetString(gitURL),
+				viper.GetString(gitRemote),
+				viper.GetString("git-token"),
+				viper.GetString(gitPath),
+				viper.GetString(componentCfg),
+				sourceBranch,
+				targetBranch,
+				graphDepth,
+				overWriteGitDepth, // viper.GetInt(gitDepth),
+				logLvl,
 			)
-		}
-	},
-	Run: func(cmd *cobra.Command, args []string) {
+			if err != nil {
+				log.Sugar.Errorf("dependency failed with: %s", err)
+				os.Exit(1)
+			}
 
-		changedDeps, err := dependencies.ChangeAffectedComponents(
-			viper.GetString(gitURL),
-			viper.GetString(gitRemote),
-			viper.GetString("git-token"),
-			viper.GetString(gitPath),
-			dependencyFile,
-			sourceBranch,
-			targetBranch,
-			graphDepth,
-			overWriteGitDepth, // viper.GetInt(gitDepth),
-			logLvl,
-		)
-		if err != nil {
-			log.Sugar.Errorf("dependency failed with: %s", err)
-			os.Exit(1)
-		}
+			writeTo, err := writeTarget(viper.GetString(gitPath), outputFile)
+			if err != nil {
+				log.Sugar.Errorf("dependency failed with: %s", err)
+				os.Exit(1)
+			}
+			changedDeps.Print(writeTo, format)
+		},
+	}
 
-		writeTo, err := writeTarget(viper.GetString(gitPath), outputFile)
-		if err != nil {
-			log.Sugar.Errorf("dependency failed with: %s", err)
-			os.Exit(1)
-		}
-		changedDeps.Print(writeTo, format)
+	c.AddCommand(newGraph())
 
-	},
-}
-
-//nolint:gochecknoinits // required by the cobra framework
-func init() {
-	cobra.OnInitialize(initDependencies)
-	rootCmd.AddCommand(dependenciesCmd)
-
-	dependenciesCmd.PersistentFlags().StringVarP(
-		&dependencyFile,
-		"dep-file", "d",
-		"coco.yaml",
-		`the dependency information file name`,
-	)
-
-	dependenciesCmd.Flags().IntVar(
-		&graphDepth,
-		"depth",
-		-1,
+	c.Flags().IntVar(
+		&graphDepth, "depth", -1,
 		`maximum depth for which downstream dependencies will be returned:
-		-1: all dependencies
-		0: only the components themselves
-		1: components and direct dependencies
+	-1: all dependencies
+	0: only the components themselves
+	1: components and direct dependencies
 		`,
 	)
-	dependenciesCmd.Flags().StringVar(
-		&outputFile,
-		"output",
-		"",
+	c.Flags().StringVar(
+		&outputFile, "output", "",
 		`specify an output filename where the results are stored. If empty results will
-		be sent to stdout.`,
+	be sent to stdout.`,
 	)
-	dependenciesCmd.Flags().StringVarP(
-		&sourceBranch,
-		"source-branch", "s",
-		"",
+	c.Flags().StringVarP(
+		&sourceBranch, "source-branch", "s", "",
 		`source branch for evaluating changed components`,
 	)
-	if err := dependenciesCmd.MarkFlagRequired("source-branch"); err != nil {
-		log.Sugar.Error(err)
-		os.Exit(1)
-	}
-	dependenciesCmd.Flags().StringVarP(
-		&targetBranch,
-		"target-branch", "t",
-		"main",
+	cobra.CheckErr(c.MarkFlagRequired("source-branch"))
+	c.Flags().StringVarP(
+		&targetBranch, "target-branch", "t", "main",
 		`target branch for evaluating changed components`,
 	)
-	if err := dependenciesCmd.MarkFlagRequired("target-branch"); err != nil {
-		log.Sugar.Error(err)
-		os.Exit(1)
-	}
+	cobra.CheckErr(c.MarkFlagRequired("target-branch"))
 
-	dependenciesCmd.PersistentFlags().StringVarP(
-		&rawFormat,
-		"format", "f",
-		"yaml",
-		"output format [yaml,json,flat]",
-	)
+	c.PersistentFlags().StringVarP(&rawFormat, "format", "f", "yaml", "output format [yaml,json,flat]")
+
+	return c
 }
 
 func writeTarget(basePath, outputFile string) (io.Writer, error) {
@@ -149,20 +126,4 @@ func writeTarget(basePath, outputFile string) (io.Writer, error) {
 		return nil, err
 	}
 	return os.Create(absPath)
-}
-
-func initDependencies() {
-	if err := log.Init(logLvl, "2006-01-02T15:04:05Z07:00", true); err != nil {
-		zap.S().Fatal(err)
-	}
-
-	var ok bool
-	format, ok = graph.CastOutputFormat(rawFormat)
-	if !ok {
-		if err := dependenciesCmd.Usage(); err != nil {
-			log.Sugar.Error(err)
-		}
-		log.Sugar.Errorf("illegal format %q", rawFormat)
-		os.Exit(1)
-	}
 }

--- a/cmd/coco/commands/generate.go
+++ b/cmd/coco/commands/generate.go
@@ -22,99 +22,82 @@ var (
 	takeControl       bool
 )
 
-// generateCmd represents the generate command
-var generateCmd = &cobra.Command{
-	Use:     "generate",
-	Aliases: []string{"gen"},
-	Short:   "generate allows to run file-generation over the gitops repository",
-	Long: `
+func newGenerate() *cobra.Command {
+	// generateCmd represents the generate command
+	var c = &cobra.Command{
+		Use:     "generate",
+		Aliases: []string{"gen"},
+		Short:   "generate allows to run file-generation over the gitops repository",
+		Long: `
 The generate command governs all aspects of non-sensitive file-generation
 in the gitops repository.
 `,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			log.Sugar.Info("no service specified - generate globally")
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				log.Sugar.Info("no service specified - generate globally")
+				return nil
+			}
 			return nil
-		}
-		return nil
-	},
-	Run: func(cmd *cobra.Command, args []string) {
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			basepath := viper.GetString(gitPath)
+			err := generate.Generate(
+				basepath,
+				tmplIdentifier,
+				persistenceFlag,
+				version.ReadAll(),
+				cleanValuePaths(valuesFolders, basepath),
+				environmentFilter,
+				args,
+				excludeFolders,
+				logLvl,
+				takeControl,
+			)
+			if err != nil {
+				log.Sugar.Errorf("generate failed: %s", err)
+				os.Exit(1)
+			}
+		},
+	}
 
-		basepath := viper.GetString(gitPath)
-		err := generate.Generate(
-			basepath,
-			tmplIdentifier,
-			persistenceFlag,
-			version.ReadAll(),
-			cleanValuePaths(valuesFolders, basepath),
-			environmentFilter,
-			args,
-			excludeFolders,
-			logLvl,
-			takeControl,
-		)
-		if err != nil {
-			log.Sugar.Errorf("generate failed: %s", err)
-			os.Exit(1)
-		}
-	},
-}
-
-//nolint:gochecknoinits // required by the cobra framework
-func init() {
-	rootCmd.AddCommand(generateCmd)
-
-	generateCmd.PersistentFlags().StringSliceVarP(
-		&environmentFilter,
-		"env-filter", "e",
-		[]string{},
+	c.PersistentFlags().StringSliceVarP(
+		&environmentFilter, "env-filter", "e", []string{},
 		"restrict the command to one or more environments",
 	)
 
-	generateCmd.Flags().StringSliceVarP(
-		&valuesFolders,
-		"values", "v",
-		[]string{"values"},
+	c.Flags().StringSliceVarP(
+		&valuesFolders, "values", "v", []string{"values"},
 		"folder that contains all value files used for rendering templates",
 	)
-	generateCmd.Flags().StringSliceVarP(
-		&excludeFolders,
-		"exclude", "x",
-		[]string{},
+	c.Flags().StringSliceVarP(
+		&excludeFolders, "exclude", "x", []string{},
 		"folders that will be excluded from file generation",
 	)
-	generateCmd.Flags().StringVarP(
-		&tmplIdentifier,
-		"templates", "t",
-		".tmpl",
+	c.Flags().StringVarP(
+		&tmplIdentifier, "templates", "t", ".tmpl",
 		"pattern in folder or file names that identifies templates for rendering",
 	)
-	generateCmd.Flags().StringVar(
-		&persistenceFlag,
-		"keep-lines",
-		"HumanInput",
+	c.Flags().StringVar(
+		&persistenceFlag, "keep-lines", "HumanInput",
 		`the value of this parameter governs which lines in generated files will not
 be overwritten by coco. Per default, all lines with the comment "# HumanInput"
 or the yaml tag "!HumanInput" will not be overwritten.`,
 	)
-	generateCmd.Flags().BoolVar(
-		&takeControl,
-		"take-control",
-		false,
+	c.Flags().BoolVar(
+		&takeControl, "take-control", false,
 		`if this flag is set, coco takes control over all generated files regardless 
 of the version in the generated files`,
 	)
-	if err := generateCmd.Flags().MarkDeprecated("take-control", "please use \"--force\" instead"); err != nil {
+	if err := c.Flags().MarkDeprecated("take-control", "please use \"--force\" instead"); err != nil {
 		zap.L().Sugar().Errorf("flag %q not found: %v", "take-control", err)
 		os.Exit(1)
 	}
-	generateCmd.Flags().BoolVar(
-		&takeControl,
-		"force",
-		false,
+	c.Flags().BoolVar(
+		&takeControl, "force", false,
 		`if this flag is set, coco forcefully regenerats all files regardless of 
 the version in the generated files`,
 	)
+	return c
 }
 
 func cleanValuePaths(valuesFolders []string, basepath string) []string {

--- a/cmd/coco/commands/graph.go
+++ b/cmd/coco/commands/graph.go
@@ -9,11 +9,12 @@ import (
 	"github.com/spf13/viper"
 )
 
-var graphCmd = &cobra.Command{
-	Use:     "graph",
-	Aliases: []string{"g"},
-	Short:   "Returns the downstream dependencies for all components in the repository",
-	Long: `This command constructs all components that depend on any given component.
+func newGraph() *cobra.Command {
+	return &cobra.Command{
+		Use:     "graph",
+		Aliases: []string{"g"},
+		Short:   "Returns the downstream dependencies for all components in the repository",
+		Long: `This command constructs all components that depend on any given component.
 	This is done by constructing the full dependency graph of upstream components
 	(defined implicitly via the direct upstream dependencies given in the 
 	dependencies.yaml file of each component) and then inverting this graph.
@@ -21,21 +22,16 @@ var graphCmd = &cobra.Command{
 	where the weight corresponds to the number of connections to reach the downstream
 	from the upstream component.
 	`,
-	Run: func(cmd *cobra.Command, args []string) {
-		deps, _, err := dependencies.Graph(
-			viper.GetString(gitPath),
-			dependencyFile,
-		)
-		if err != nil {
-			log.Sugar.Errorf("graph failed with: %s", err)
-			os.Exit(1)
-		}
-		deps.Print(os.Stdout, format)
-
-	},
-}
-
-//nolint:gochecknoinits // required by the cobra framework
-func init() {
-	dependenciesCmd.AddCommand(graphCmd)
+		Run: func(cmd *cobra.Command, args []string) {
+			deps, _, err := dependencies.Graph(
+				viper.GetString(gitPath),
+				viper.GetString(componentCfg),
+			)
+			if err != nil {
+				log.Sugar.Errorf("graph failed with: %s", err)
+				os.Exit(1)
+			}
+			deps.Print(os.Stdout, format)
+		},
+	}
 }

--- a/cmd/coco/commands/inspect.go
+++ b/cmd/coco/commands/inspect.go
@@ -1,0 +1,23 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+func newInspect() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "inspect",
+		Short: "show the current coco configuration",
+		Long:  `Returns the configuration of coco as well as the default configuration options.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg, err := yaml.Marshal(viper.AllSettings())
+			cobra.CheckErr(err)
+			fmt.Println(string(cfg))
+		},
+	}
+	return c
+}

--- a/cmd/coco/commands/utils.go
+++ b/cmd/coco/commands/utils.go
@@ -1,0 +1,12 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+func bindFlag(fs *pflag.FlagSet, key, flag, env string) {
+	cobra.CheckErr(viper.BindPFlag(key, fs.Lookup(flag)))
+	cobra.CheckErr(viper.BindEnv(key, env))
+}

--- a/cmd/coco/commands/version.go
+++ b/cmd/coco/commands/version.go
@@ -7,18 +7,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// generateCmd represents the generate command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "coco version",
-	Long: `The version command returns version and additional information about 
+func newVersion() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "coco version",
+		Long: `The version command returns version and additional information about 
 the coco binary`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("%+v\n", version.ReadAll())
-	},
-}
-
-//nolint:gochecknoinits // required by the cobra framework
-func init() {
-	rootCmd.AddCommand(versionCmd)
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("%+v\n", version.ReadAll())
+		},
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-git/go-git/v5 v5.6.1
 	github.com/google/uuid v1.3.0
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869
 	go.uber.org/zap v1.24.0
@@ -39,7 +40,6 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.uber.org/atomic v1.10.0 // indirect


### PR DESCRIPTION
- remove init functions from cmd package
- use function hierarchies instead of init functions for predictible initializations