### PR TITLE
feat(reconcile): user interactions via flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Configuration tools for GitOps
 
-![Coverage](https://img.shields.io/badge/Coverage-85.1%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-85.2%25-brightgreen)
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/configuration-tools-for-gitops)](https://api.reuse.software/info/github.com/SAP/configuration-tools-for-gitops)
 
 ## About this project

--- a/cmd/coco/commands/reconcile.go
+++ b/cmd/coco/commands/reconcile.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	owner string
-	repo  string
+	owner          string
+	repo           string
+	forceReconcile bool
 )
 
 var (
@@ -61,7 +62,7 @@ func newReconcile() *cobra.Command {
 				os.Exit(1)
 			}
 
-			err = client.Reconcile()
+			err = client.Reconcile(forceReconcile)
 			if err != nil {
 				log.Sugar.Errorf("reconciliation failed with: %w", err)
 				os.Exit(1)
@@ -89,5 +90,9 @@ func newReconcile() *cobra.Command {
 		log.Sugar.Error(err)
 		os.Exit(1)
 	}
+	c.Flags().BoolVar(
+		&forceReconcile, "force", false,
+		`Allows coco to forcefully deletes the reconcile branch if required.`,
+	)
 	return c
 }

--- a/cmd/coco/reconcile/reconcile.go
+++ b/cmd/coco/reconcile/reconcile.go
@@ -25,7 +25,7 @@ func New(sourceBranch, targetBranch, owner, repo, token string, ctx context.Cont
 
 	// Authenticate with Github
 	// target is base and source is head
-	client, err := newGithubClient(token, owner, repo, ctx)
+	client, err := githubClient(token, owner, repo, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to authenticate with Github: %w", err)
 	}
@@ -174,9 +174,7 @@ func (r *ReconcileClient) handleTargetAhead(force bool) (bool, error) {
 }
 
 var (
-	newGithubClient = func(token, owner, repo string, ctx context.Context) (github.Interface, error) {
-		return github.New(token, owner, repo, ctx)
-	}
+	githubClient  = github.New
 	printTerminal = terminal.Output
 	confirmed     = terminal.IsYes
 )

--- a/cmd/coco/reconcile/reconcile_test.go
+++ b/cmd/coco/reconcile/reconcile_test.go
@@ -149,7 +149,7 @@ func TestReconcilition(t *testing.T) {
 
 	for _, tt := range scenarios {
 		t.Run(tt.title, func(t *testing.T) {
-			newGithubClient = func(token, owner, repo string, ctx context.Context) (github.Interface, error) {
+			githubClient = func(token, owner, repo string, ctx context.Context) (github.Interface, error) {
 				return github.Mock(
 					owner, repo,
 					tt.reconcileBranchExists,

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -86,12 +86,8 @@ func (gh *github) CompareCommits(
 	return commits, err
 }
 
-func (gh *github) DeleteBranch(branchName string, force bool) error {
-	delete := false
-	if force {
-		delete = true
-	}
-	if !delete {
+func (gh *github) DeleteBranch(branchName string, forceDelete bool) error {
+	if !forceDelete {
 		printTerminal(
 			fmt.Sprintf(
 				"\n\nYou will lose all the changes made in the reconcile branch. "+
@@ -106,11 +102,11 @@ func (gh *github) DeleteBranch(branchName string, force bool) error {
 			return nil
 		}
 		if strings.EqualFold(input, "y") {
-			delete = true
+			forceDelete = true
 		}
 	}
 
-	if delete {
+	if forceDelete {
 		_, err := gh.client.Git.DeleteRef(
 			gh.ctx, gh.owner, gh.repo, "refs/heads/"+branchName,
 		)

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -18,7 +18,6 @@ func Mock(
 	owner, repo string,
 	reconcileBranchExists, targetAhead, mergeSuccessful bool,
 ) (Interface, error) {
-
 	return &mock{
 		owner,
 		repo,

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -1,16 +1,12 @@
 package github
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/google/go-github/v51/github"
-	"golang.org/x/oauth2"
+	gogithub "github.com/google/go-github/v51/github"
 )
 
-type Mock struct {
-	client                *github.Client
-	ctx                   context.Context
+type mock struct {
 	owner                 string
 	repo                  string
 	reconcileBranchExists bool
@@ -18,23 +14,12 @@ type Mock struct {
 	mergeSuccessful       bool
 }
 
-func NewMock(
-	token,
-	owner,
-	repo string,
-	ctx context.Context,
-	reconcileBranchExists,
-	targetAhead,
-	mergeSuccessful bool) (*Mock, error) {
-	// Authenticate with Github
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-	client := github.NewClient(tc)
-	return &Mock{
-		client,
-		ctx,
+func Mock(
+	owner, repo string,
+	reconcileBranchExists, targetAhead, mergeSuccessful bool,
+) (Interface, error) {
+
+	return &mock{
 		owner,
 		repo,
 		reconcileBranchExists,
@@ -43,7 +28,7 @@ func NewMock(
 	}, nil
 }
 
-func (gh *Mock) MergeBranches(base, head string) (bool, error) {
+func (gh *mock) MergeBranches(base, head string) (bool, error) {
 	if gh.mergeSuccessful {
 		return true, nil
 	} else {
@@ -51,7 +36,7 @@ func (gh *Mock) MergeBranches(base, head string) (bool, error) {
 	}
 }
 
-func (gh *Mock) GetBranch(branchName string) (*github.Branch, int, error) {
+func (gh *mock) GetBranch(branchName string) (*gogithub.Branch, int, error) {
 	dummySHA := "dd0b557d0696d2e1b8a1cf9de6b3c6d3a3a8a8f9"
 	var status int
 	if gh.reconcileBranchExists {
@@ -59,59 +44,59 @@ func (gh *Mock) GetBranch(branchName string) (*github.Branch, int, error) {
 	} else {
 		status = 404
 	}
-	return &github.Branch{
+	return &gogithub.Branch{
 		Name: &branchName,
-		Commit: &github.RepositoryCommit{
+		Commit: &gogithub.RepositoryCommit{
 			SHA: &dummySHA,
 		},
 	}, status, nil
 }
 
-func (gh *Mock) CompareCommits(branch1, branch2 *github.Branch) (*github.CommitsComparison, error) {
+func (gh *mock) CompareCommits(branch1, branch2 *gogithub.Branch) (*gogithub.CommitsComparison, error) {
 	var aheadBy int
 	if gh.targetAhead {
 		aheadBy = 2
 	} else {
 		aheadBy = 0
 	}
-	return &github.CommitsComparison{
+	return &gogithub.CommitsComparison{
 		// head is ahead of base
 		AheadBy: &aheadBy,
 	}, nil
 }
 
-func (gh *Mock) DeleteBranch(branchName string) error {
+func (gh *mock) DeleteBranch(branchName string, force bool) error {
 	return nil
 }
 
-func (gh *Mock) GetBranchRef(branchName string) (*github.Reference, error) {
-	return &github.Reference{}, nil
+func (gh *mock) GetBranchRef(branchName string) (*gogithub.Reference, error) {
+	return &gogithub.Reference{}, nil
 }
 
-func (gh *Mock) CreateBranch(branchName string, target *github.Reference) error {
+func (gh *mock) CreateBranch(branchName string, target *gogithub.Reference) error {
 	return nil
 }
 
-func (gh *Mock) CreatePullRequest(head, base string) (*github.PullRequest, error) {
+func (gh *mock) CreatePullRequest(head, base string) (*gogithub.PullRequest, error) {
 	prNumber := 1
-	url := fmt.Sprintf("www.github.com/%s/%s/pulls/%v", gh.owner, gh.repo, prNumber)
-	return &github.PullRequest{
+	url := fmt.Sprintf("www.gogithub.com/%s/%s/pulls/%v", gh.owner, gh.repo, prNumber)
+	return &gogithub.PullRequest{
 		Number:  &prNumber,
 		HTMLURL: &url,
 	}, nil
 }
 
-func (gh *Mock) ListPullRequests() ([]*github.PullRequest, error) {
-	var prs []*github.PullRequest
+func (gh *mock) ListPullRequests() ([]*gogithub.PullRequest, error) {
+	var prs []*gogithub.PullRequest
 	reconcileBranchName := fmt.Sprintf("reconcile/%s-%s", "feature", "main")
-	pr := &github.PullRequest{
-		Head: &github.PullRequestBranch{
-			Ref: github.String("feature"),
+	pr := &gogithub.PullRequest{
+		Head: &gogithub.PullRequestBranch{
+			Ref: gogithub.String("feature"),
 		},
-		Base: &github.PullRequestBranch{
-			Ref: github.String(reconcileBranchName),
+		Base: &gogithub.PullRequestBranch{
+			Ref: gogithub.String(reconcileBranchName),
 		},
-		Mergeable: github.Bool(true),
+		Mergeable: gogithub.Bool(true),
 	}
 	prs = append(prs, pr)
 	return prs, nil

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -19,3 +19,21 @@ func ReadStr() (string, error) {
 	_, err := fmt.Scanln(&res)
 	return res, err
 }
+
+var (
+	AffirmationOptions = []string{"y", "yes"}
+)
+
+func IsYes() (bool, error) {
+	var res string
+	_, err := fmt.Scanln(&res)
+	if err != nil {
+		return false, err
+	}
+	for _, o := range AffirmationOptions {
+		if res == o {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
This feature adds a `--force` flag to the reconcile command.

Behaviour:
When this flag is set, questions at runtime to the user will be suppressed and instead the reconciliation branch will be deleted directly by coco if required.