### PR TITLE
feat: added enterprise functionality

### DIFF
--- a/cmd/coco/commands/reconcile.go
+++ b/cmd/coco/commands/reconcile.go
@@ -12,9 +12,12 @@ import (
 )
 
 var (
-	owner          string
-	repo           string
-	forceReconcile bool
+	owner           string
+	repo            string
+	forceReconcile  bool
+	isEnterprise    bool
+	githubBaseURL   string
+	githubUploadURL string
 )
 
 var (
@@ -26,9 +29,9 @@ func newReconcile() *cobra.Command {
 		Use:   "reconcile",
 		Short: "Reconciles a target branch with source branch",
 		Long: `The command is intended to reconcile a target branch with a source branch
-		by merging them. The reconciling process involves creating a new branch with the 
-		name "reconcile/{target_branch}," where {target_branch} is the name of the 
-		target branch, merging the source branch into the target branch, and 
+		by merging them. The reconciling process involves creating a new branch with the
+		name "reconcile/{target_branch}," where {target_branch} is the name of the
+		target branch, merging the source branch into the target branch, and
 		pushing the result to the remote repository`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if viper.GetString("git-token") == "" {
@@ -55,6 +58,9 @@ func newReconcile() *cobra.Command {
 				owner,
 				repo,
 				viper.GetString("git-token"),
+				githubBaseURL,
+				githubUploadURL,
+				isEnterprise,
 				ctx,
 			)
 			if err != nil {
@@ -93,6 +99,18 @@ func newReconcile() *cobra.Command {
 	c.Flags().BoolVar(
 		&forceReconcile, "force", false,
 		`Allows coco to forcefully deletes the reconcile branch if required.`,
+	)
+	c.Flags().BoolVar(
+		&isEnterprise, "enterprise", false,
+		`Uses GitHub Enterprise hostname.`,
+	)
+	c.Flags().StringVar(
+		&githubBaseURL, "githubBaseURL", "https://github.com",
+		`baseURL for GitHub Enterprise usage (often is your GitHub Enterprise hostname).`,
+	)
+	c.Flags().StringVar(
+		&githubUploadURL, "githubUploadURL", "https://github.com",
+		`uploadURL for GitHub Enterprise usage (often is your GitHub Enterprise hostname)`,
 	)
 	return c
 }

--- a/cmd/coco/reconcile/reconcile.go
+++ b/cmd/coco/reconcile/reconcile.go
@@ -20,12 +20,13 @@ type ReconcileClient struct {
 	repo                string
 }
 
-func New(sourceBranch, targetBranch, owner, repo, token string, ctx context.Context) (*ReconcileClient, error) {
+func New(sourceBranch, targetBranch, owner, repo, token, githubBaseURL, githubUploadURL string, isEnterprise bool,
+	ctx context.Context) (*ReconcileClient, error) {
 	reconcileBranchName := fmt.Sprintf("reconcile/%s-%s", sourceBranch, targetBranch)
 
 	// Authenticate with Github
 	// target is base and source is head
-	client, err := githubClient(token, owner, repo, ctx)
+	client, err := githubClient(token, owner, repo, githubBaseURL, githubUploadURL, ctx, isEnterprise)
 	if err != nil {
 		return nil, fmt.Errorf("failed to authenticate with Github: %w", err)
 	}

--- a/cmd/coco/reconcile/reconcile_test.go
+++ b/cmd/coco/reconcile/reconcile_test.go
@@ -149,7 +149,8 @@ func TestReconcilition(t *testing.T) {
 
 	for _, tt := range scenarios {
 		t.Run(tt.title, func(t *testing.T) {
-			githubClient = func(token, owner, repo string, ctx context.Context) (github.Interface, error) {
+			githubClient = func(token, owner, repo, baseURL, uploadURL string, ctx context.Context,
+				isEnterprise bool) (github.Interface, error) {
 				return github.Mock(
 					owner, repo,
 					tt.reconcileBranchExists,
@@ -169,7 +170,7 @@ func TestReconcilition(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			client, err := New(tt.sourceBranch, tt.targetBranch, tt.owner, tt.repo, token, ctx)
+			client, err := New(tt.sourceBranch, tt.targetBranch, tt.owner, tt.repo, token, "", "", false, ctx)
 			if err != nil && err.Error() != tt.expectedErr.Error() {
 				t.Errorf("unexpected error: got %q, want %q", err, tt.expectedErr)
 			}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -22,13 +22,24 @@ type Interface interface {
 	MergeBranches(base, head string) (bool, error)
 }
 
-func New(token, owner, repo string, ctx context.Context) (Interface, error) {
+func New(token, owner, repo, baseURL, uploadURL string, ctx context.Context, isEnterprise bool) (Interface, error) {
 	// Authenticate with Github
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
 	tc := oauth2.NewClient(ctx, ts)
-	client := gogithub.NewClient(tc)
+	var client *gogithub.Client
+	var err error
+
+	if isEnterprise {
+		client, err = gogithub.NewEnterpriseClient(baseURL, uploadURL, tc)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		client = gogithub.NewClient(tc)
+	}
+
 	return &github{
 		client,
 		ctx,


### PR DESCRIPTION
Introduces an enterprise flag for enabling users to utilise the GitHub Enterprise hostname. By including this flag, users gain the ability to leverage their organisation's specific GitHub Enterprise environment.