### PR TITLE
feat!: environment and dependencies definition via configfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Configuration tools for GitOps
 
-![Coverage](https://img.shields.io/badge/Coverage-85.1%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-85.4%25-brightgreen)
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/configuration-tools-for-gitops)](https://api.reuse.software/info/github.com/SAP/configuration-tools-for-gitops)
 
 ## About this project

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Configuration tools for GitOps
 
-![Coverage](https://img.shields.io/badge/Coverage-85.4%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-85.3%25-brightgreen)
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/configuration-tools-for-gitops)](https://api.reuse.software/info/github.com/SAP/configuration-tools-for-gitops)
 
 ## About this project

--- a/cmd/coco/commands/generate.go
+++ b/cmd/coco/commands/generate.go
@@ -41,10 +41,12 @@ in the gitops repository.
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			basepath := viper.GetString(gitPathKey)
+			configFileName := viper.GetString(componentCfg)
 			err := generate.Generate(
 				basepath,
 				tmplIdentifier,
 				persistenceFlag,
+				configFileName,
 				version.ReadAll(),
 				cleanValuePaths(valuesFolders, basepath),
 				environmentFilter,

--- a/cmd/coco/commands/inspect.go
+++ b/cmd/coco/commands/inspect.go
@@ -2,7 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/SAP/configuration-tools-for-gitops/cmd/coco/inputfile"
+	"github.com/SAP/configuration-tools-for-gitops/pkg/yamlfile"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -19,5 +22,19 @@ func newInspect() *cobra.Command {
 			fmt.Println(string(cfg))
 		},
 	}
+	c.AddCommand(NewInspectValues())
 	return c
+}
+
+func NewInspectValues() *cobra.Command {
+	return &cobra.Command{
+		Use:   "values",
+		Short: "options for environment values",
+		Long:  `Returns the default configuration options.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			docsYaml, err := yamlfile.NewFromInterface(yamlfile.DocOutput(inputfile.Coco{}))
+			cobra.CheckErr(err)
+			cobra.CheckErr(docsYaml.Encode(os.Stdout, 2))
+		},
+	}
 }

--- a/cmd/coco/dependencies/graph.go
+++ b/cmd/coco/dependencies/graph.go
@@ -3,6 +3,8 @@ package dependencies
 import (
 	"path/filepath"
 
+	"github.com/SAP/configuration-tools-for-gitops/cmd/coco/inputfile"
+
 	g "github.com/SAP/configuration-tools-for-gitops/cmd/coco/graph"
 	"github.com/SAP/configuration-tools-for-gitops/pkg/files"
 	"github.com/SAP/configuration-tools-for-gitops/pkg/log"
@@ -10,8 +12,8 @@ import (
 )
 
 var (
-	unmarshal    func([]byte, interface{}) error            = yaml.Unmarshal
-	dependencies func(string, string) (*files.Files, error) = deps
+	unmarshal    func([]byte, interface{}) error                                                   = yaml.Unmarshal
+	dependencies func(string, string, []string, []string, []string) (map[string]files.File, error) = inputfile.FindAll
 )
 
 func Graph(path, depFileName string) (
@@ -35,11 +37,10 @@ func logErr(c log.Context, err error) bool {
 func constructGraph(path, depFileName string) (
 	downToUp g.DownToUp, componentPaths map[string]string, err error,
 ) {
-	depFiles, err := dependencies(path, depFileName)
+	fs, err := dependencies(path, depFileName, []string{}, []string{}, []string{})
 	if err != nil {
 		return
 	}
-	fs := depFiles.Content()
 
 	downToUp = make(g.DownToUp, len(fs))
 	componentPaths = make(map[string]string, len(fs))
@@ -49,7 +50,13 @@ func constructGraph(path, depFileName string) (
 			continue
 		}
 
-		var df depFile
+		df, err := inputfile.Load(p)
+		if !df.IsComponent() {
+			continue
+		}
+		if err != nil {
+			return downToUp, componentPaths, err
+		}
 		if err := unmarshal(f.Content, &df); err != nil {
 			return downToUp, componentPaths, err
 		}
@@ -78,16 +85,4 @@ func relativeComponentPath(p, path string) string {
 		return cleanedPath[1:]
 	}
 	return cleanedPath
-}
-
-type depFile struct {
-	Name         string   `yaml:"name"`
-	Dependencies []string `yaml:"dependencies"`
-}
-
-func deps(path, depFileName string) (*files.Files, error) {
-	return files.New(path).
-		Include(files.AND, []string{depFileName}).
-		ReadContent().
-		Execute()
 }

--- a/cmd/coco/dependencies/graph.go
+++ b/cmd/coco/dependencies/graph.go
@@ -51,13 +51,16 @@ func constructGraph(path, depFileName string) (
 		}
 
 		df, err := inputfile.Load(p)
-		if !df.IsComponent() {
-			continue
-		}
 		if err != nil {
 			return downToUp, componentPaths, err
 		}
-		if err := unmarshal(f.Content, &df); err != nil {
+
+		if !df.IsComponent() {
+			continue
+		}
+
+		err = unmarshal(f.Content, &df)
+		if err != nil {
 			return downToUp, componentPaths, err
 		}
 

--- a/cmd/coco/dependencies/graph_test.go
+++ b/cmd/coco/dependencies/graph_test.go
@@ -225,11 +225,13 @@ func (m mockGraph) unmarshal(in []byte, out interface{}) error {
 	return yaml.Unmarshal(in, out)
 }
 
-func (m mockGraph) readDeps(path,
+func (m mockGraph) readDeps(
+	path,
 	depFileName string,
 	includeOr,
 	includeAnd,
-	exclude []string) (map[string]files.File, error) {
+	exclude []string,
+) (map[string]files.File, error) {
 	if m.rd != nil {
 		return nil, m.rd
 	}

--- a/cmd/coco/dependencies/graph_test.go
+++ b/cmd/coco/dependencies/graph_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/SAP/configuration-tools-for-gitops/cmd/coco/inputfile"
+
 	"github.com/SAP/configuration-tools-for-gitops/cmd/coco/graph"
 	"github.com/SAP/configuration-tools-for-gitops/pkg/files"
 	"github.com/SAP/configuration-tools-for-gitops/pkg/log"
@@ -34,7 +36,7 @@ var graphScenarios = []graphTest{
 	{
 		title: "happy path empty",
 		input: input{
-			depFileName: "dependencies.yaml",
+			depFileName: "coco.yaml",
 			files:       map[string][]byte{"someOtherFile": {}},
 			mock: mockGraph{
 				rf: nil,
@@ -50,13 +52,15 @@ var graphScenarios = []graphTest{
 	{
 		title: "happy path no dependencies",
 		input: input{
-			depFileName: "dependencies.yaml",
+			depFileName: "coco.yaml",
 			files: map[string][]byte{
-				"component-1/dependencies.yaml": []byte(string(`
+				"component-1/coco.yaml": []byte(string(`
+type: component
 name: component-1
 dependencies:
 `)),
-				"component-2/dependencies.yaml": []byte(string(`
+				"component-2/coco.yaml": []byte(string(`
+type: component
 name: component-2
 dependencies:
 `)),
@@ -78,15 +82,17 @@ dependencies:
 	{
 		title: "happy path with dependencies",
 		input: input{
-			depFileName: "dependencies.yaml",
+			depFileName: "coco.yaml",
 			files: map[string][]byte{
-				"component-1/dependencies.yaml": []byte(string(`
+				"component-1/coco.yaml": []byte(string(`
+type: component
 name: component-1
 dependencies:
 - component-2
 - unknown-component
 `)),
-				"component-2/dependencies.yaml": []byte(string(`
+				"component-2/coco.yaml": []byte(string(`
+type: component
 name: component-2
 dependencies:
 `)),
@@ -109,8 +115,13 @@ dependencies:
 	{
 		title: "folder selected",
 		input: input{
-			depFileName: "folder",
-			files:       map[string][]byte{"folder/otherFile": {}},
+			depFileName: "coco.yaml",
+			files: map[string][]byte{
+				"coco.yaml": []byte(`
+type: component
+dependencies:
+`),
+				"folder/otherFile": {}},
 			mock: mockGraph{
 				rf: nil,
 				un: nil,
@@ -125,7 +136,7 @@ dependencies:
 	{
 		title: "error in readDeps",
 		input: input{
-			depFileName: "dependencies.yaml",
+			depFileName: "coco.yaml",
 			files:       map[string][]byte{},
 			mock: mockGraph{
 				rf: nil,
@@ -141,8 +152,13 @@ dependencies:
 	{
 		title: "error in unmarshal",
 		input: input{
-			depFileName: "file",
-			files:       map[string][]byte{"file": {}},
+			depFileName: "coco.yaml",
+			files: map[string][]byte{"coco.yaml": []byte(`
+type: component
+name: component-1
+dependencies:
+  - dep1`),
+				"dep1": {}},
 			mock: mockGraph{
 				rf: nil,
 				un: fmt.Errorf("fail in unmarshal"),
@@ -209,9 +225,13 @@ func (m mockGraph) unmarshal(in []byte, out interface{}) error {
 	return yaml.Unmarshal(in, out)
 }
 
-func (m mockGraph) readDeps(path, depFileName string) (*files.Files, error) {
+func (m mockGraph) readDeps(path,
+	depFileName string,
+	includeOr,
+	includeAnd,
+	exclude []string) (map[string]files.File, error) {
 	if m.rd != nil {
 		return nil, m.rd
 	}
-	return deps(path, depFileName)
+	return inputfile.FindAll(path, depFileName, includeOr, includeAnd, exclude)
 }

--- a/cmd/coco/dependencies/readme.md
+++ b/cmd/coco/dependencies/readme.md
@@ -6,6 +6,7 @@ the `git.path`. A component is identified by a `coco.yaml` file with the format:
 ```yaml
 # coco.yaml content
 
+type: component
 name: name of the component
 dependencies:
   - list of

--- a/cmd/coco/generate/findvaluefiles.go
+++ b/cmd/coco/generate/findvaluefiles.go
@@ -20,7 +20,6 @@ func readValueFiles(
 			continue
 		}
 
-		var coco inputfile.Coco
 		coco, err := inputfile.Load(path)
 		if err != nil {
 			return nil, err

--- a/cmd/coco/generate/findvaluefiles.go
+++ b/cmd/coco/generate/findvaluefiles.go
@@ -3,42 +3,60 @@ package generate
 import (
 	"bytes"
 	"path/filepath"
-	"strings"
 
-	"github.com/SAP/configuration-tools-for-gitops/pkg/files"
+	"github.com/SAP/configuration-tools-for-gitops/cmd/coco/inputfile"
 	"gopkg.in/yaml.v3"
 )
 
 func readValueFiles(
-	basepath string,
+	basepath, configFileName string,
 	includeOr, includeAnd, exclude []string,
 ) (map[string]interface{}, error) {
-	fileRunner := files.New(basepath).
-		Include(files.OR, includeOr).
-		Include(files.AND, includeAnd).
-		Exclude(files.OR, exclude).
-		ReadContent()
-
-	if len(includeAnd) > 0 {
-		fileRunner = fileRunner.Include(files.AND, includeAnd)
-	}
-	vFiles, err := fileRunner.Execute()
+	valueFiles, err := inputfile.FindAll(basepath, configFileName, includeOr, includeAnd, exclude)
 	if err != nil {
 		return nil, err
 	}
-	valueFiles := vFiles.Content()
 	res := make(map[string]interface{}, len(valueFiles))
 	for path, file := range valueFiles {
 		if file.IsDir {
 			continue
 		}
-		d := yaml.NewDecoder(bytes.NewReader(file.Content))
-		var values interface{}
-		err := d.Decode(&values)
+
+		var coco inputfile.Coco
+		coco, err := inputfile.Load(path)
 		if err != nil {
 			return nil, err
 		}
-		res[strings.Replace(filepath.Base(path), ".yaml", "", 1)] = values
+
+		if !coco.IsEnvironment() {
+			continue
+		}
+
+		dir := filepath.Dir(path)
+		var valueFilesForEnv []string
+		for _, v := range coco.Values {
+			valueFilesForEnv = append(valueFilesForEnv, dir+"/"+v+".yaml")
+		}
+
+		merged, err := mergeValues(valueFilesForEnv)
+		if err != nil {
+			return nil, err
+		}
+		var renderedData bytes.Buffer
+		err = merged.Encode(&renderedData, 2)
+		if err != nil {
+			return nil, err
+		}
+
+		var finalValues interface{}
+		finalValuesDecoder := yaml.NewDecoder(bytes.NewReader(renderedData.Bytes()))
+
+		err = finalValuesDecoder.Decode(&finalValues)
+		if err != nil {
+			return nil, err
+		}
+
+		res[coco.Name] = finalValues
 	}
 	return res, nil
 }

--- a/cmd/coco/generate/findvaluefiles.go
+++ b/cmd/coco/generate/findvaluefiles.go
@@ -1,11 +1,9 @@
 package generate
 
 import (
-	"bytes"
 	"path/filepath"
 
 	"github.com/SAP/configuration-tools-for-gitops/cmd/coco/inputfile"
-	"gopkg.in/yaml.v3"
 )
 
 func readValueFiles(
@@ -33,28 +31,22 @@ func readValueFiles(
 		}
 
 		dir := filepath.Dir(path)
-		var valueFilesForEnv []string
+		valueFilesForEnv := make([]string, 0, len(coco.Values))
 		for _, v := range coco.Values {
-			valueFilesForEnv = append(valueFilesForEnv, dir+"/"+v+".yaml")
+			valueFilesForEnv = append(valueFilesForEnv, filepath.Join(dir, v))
 		}
 
 		merged, err := mergeValues(valueFilesForEnv)
 		if err != nil {
 			return nil, err
 		}
-		var renderedData bytes.Buffer
-		err = merged.Encode(&renderedData, 2)
-		if err != nil {
-			return nil, err
-		}
 
 		var finalValues interface{}
-		finalValuesDecoder := yaml.NewDecoder(bytes.NewReader(renderedData.Bytes()))
-
-		err = finalValuesDecoder.Decode(&finalValues)
+		err = merged.Decode(&finalValues)
 		if err != nil {
 			return nil, err
 		}
+		res[coco.Name] = finalValues
 
 		res[coco.Name] = finalValues
 	}

--- a/cmd/coco/generate/findvaluefiles_test.go
+++ b/cmd/coco/generate/findvaluefiles_test.go
@@ -2,8 +2,14 @@ package generate
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
+	"sort"
 	"testing"
+
+	"github.com/SAP/configuration-tools-for-gitops/cmd/coco/inputfile"
+	"github.com/SAP/configuration-tools-for-gitops/pkg/maputils"
+	"github.com/spf13/viper"
 
 	"github.com/SAP/configuration-tools-for-gitops/pkg/testfuncs"
 	"gopkg.in/yaml.v3"
@@ -18,6 +24,11 @@ type scenarioValueFiles struct {
 	wantErr        error
 }
 
+var (
+	allConfigTypes = sortConfigTypes(maputils.Keys(inputfile.AllConfigTypes))
+	configFileName = "coco.yaml"
+)
+
 var scenariosValueFiles = []scenarioValueFiles{
 	{
 		title:          "working general example",
@@ -28,21 +39,41 @@ var scenariosValueFiles = []scenarioValueFiles{
 			"folder/name.tmpl":               nil,
 			"values/.tmpl/test":              nil,
 			"values/name.tmpl":               nil,
-			"values/file1.yaml":              []byte(`k1: v1`),
-			"values/file2": []byte(`
+			"values/env1/file1.yaml":         []byte(`k1: v1`),
+			"values/env1/file2.yaml": []byte(`
 k2: v2
 k22: v22
 `),
-			"values2/file3": nil,
-			"values2/file4": nil,
-			"values3/file3": nil,
-			"values3/file4": nil,
+			"values2/env2/file3": nil,
+			"values2/env2/file4": nil,
+			"values/env2/file3.yaml": []byte(`
+k3: v3
+k33: v33
+`),
+			"values/env2/file4.yaml": []byte(`k4: v4`),
+			"values/env1/coco.yaml": []byte(`
+type: environment
+name: name1
+values: 
+  - file1
+  - file2
+`),
+			"values/env2/coco.yaml": []byte(`
+type: environment
+name: name2
+values: 
+  - file3
+`),
 		},
 		wantFiles: map[string][]byte{
-			"file1": []byte(`k1: v1`),
-			"file2": []byte(`
+			"name1": []byte(`
+k1: v1
 k2: v2
 k22: v22
+`),
+			"name2": []byte(`
+k3: v3
+k33: v33
 `),
 		},
 		wantErr: nil,
@@ -56,30 +87,65 @@ k22: v22
 			"folder/name.tmpl":               nil,
 			"values/.tmpl/test":              nil,
 			"values/name.tmpl":               nil,
-			"values/file1":                   []byte(`k1: v1`),
-			"values/file2": []byte(`
+			"values/env1/file1.yaml":         []byte(`k1: v1`),
+			"values/env1/file2.yaml": []byte(`
 k2: v2
 k22: v22
 `),
-			"values2/file3": []byte(`k3: v3`),
-			"values2/file4": []byte(`k4: v4`),
-			"values3/file3": nil,
-			"values3/file4": nil,
+			"values/env2/file3": nil,
+			"values/env2/file4": nil,
+			"values2/env/file3.yaml": []byte(`
+k3: v3
+k33: v33
+`),
+			"values2/env/file4.yaml": []byte(`k4: v4`),
+			"values/env1/coco.yaml": []byte(`
+type: environment
+name: name1
+values: 
+  - file1
+  - file2
+`),
+			"values2/env/coco.yaml": []byte(`
+type: environment
+name: name2
+values: 
+  - file3
+`),
 		},
 		wantFiles: map[string][]byte{
-			"file1": []byte(`k1: v1`),
-			"file2": []byte(`
+			"name1": []byte(`
+k1: v1
 k2: v2
 k22: v22
 `),
-			"file3": []byte(`k3: v3`),
-			"file4": []byte(`k4: v4`),
+			"name2": []byte(`
+k3: v3
+k33: v33
+`),
 		},
 		wantErr: nil,
+	},
+	{
+		title:          "Unsupported coco type",
+		includeFilters: []string{"${BASEPATH}/values/", "${BASEPATH}/values2/"},
+		excludeFilters: []string{".tmpl"},
+		files: map[string][]byte{
+			"values/coco.yaml": []byte(`
+type: unsupportedType
+`),
+		},
+		wantFiles: nil,
+		wantErr: fmt.Errorf(
+			"unsupported type: %q, available options: %+v",
+			"unsupportedType",
+			allConfigTypes,
+		),
 	},
 }
 
 func TestFindValueFiles(t *testing.T) {
+	fmt.Println(viper.GetString("component.cfg"))
 	for _, s := range scenariosValueFiles {
 		t.Logf("test scenario: %s\n", s.title)
 		s.Test(t)
@@ -95,14 +161,17 @@ func (s *scenarioValueFiles) Test(t *testing.T) {
 	defer td.Cleanup(t)
 	tmpDir := td.Path()
 
-	got, err := readValueFiles(tmpDir, s.includeFilters, []string{}, s.excludeFilters)
+	got, err := readValueFiles(tmpDir, configFileName, s.includeFilters, []string{}, s.excludeFilters)
 	testfuncs.CheckErrs(t, s.wantErr, err)
 
 	s.CheckRes(t, tmpDir, got)
 }
 
 func (s *scenarioValueFiles) CheckRes(t *testing.T, basedir string, got map[string]interface{}) {
-	expected := make(map[string]interface{}, len(s.wantFiles))
+	var expected map[string]interface{}
+	if len(s.wantFiles) > 0 {
+		expected = make(map[string]interface{}, len(s.wantFiles))
+	}
 
 	for name, rawValues := range s.wantFiles {
 		d := yaml.NewDecoder(bytes.NewReader(rawValues))
@@ -119,4 +188,11 @@ func (s *scenarioValueFiles) CheckRes(t *testing.T, basedir string, got map[stri
 		)
 		t.Fail()
 	}
+}
+
+func sortConfigTypes(a []inputfile.ConfigType) []inputfile.ConfigType {
+	sort.Slice(a, func(i, j int) bool {
+		return a[i] < a[j]
+	})
+	return a
 }

--- a/cmd/coco/generate/findvaluefiles_test.go
+++ b/cmd/coco/generate/findvaluefiles_test.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/SAP/configuration-tools-for-gitops/cmd/coco/inputfile"
 	"github.com/SAP/configuration-tools-for-gitops/pkg/maputils"
-	"github.com/spf13/viper"
 
 	"github.com/SAP/configuration-tools-for-gitops/pkg/testfuncs"
 	"gopkg.in/yaml.v3"
@@ -25,7 +23,7 @@ type scenarioValueFiles struct {
 }
 
 var (
-	allConfigTypes = sortConfigTypes(maputils.Keys(inputfile.AllConfigTypes))
+	allConfigTypes = maputils.KeysSorted(inputfile.AllConfigTypes)
 	configFileName = "coco.yaml"
 )
 
@@ -145,7 +143,6 @@ type: unsupportedType
 }
 
 func TestFindValueFiles(t *testing.T) {
-	fmt.Println(viper.GetString("component.cfg"))
 	for _, s := range scenariosValueFiles {
 		t.Logf("test scenario: %s\n", s.title)
 		s.Test(t)
@@ -188,11 +185,4 @@ func (s *scenarioValueFiles) CheckRes(t *testing.T, basedir string, got map[stri
 		)
 		t.Fail()
 	}
-}
-
-func sortConfigTypes(a []inputfile.ConfigType) []inputfile.ConfigType {
-	sort.Slice(a, func(i, j int) bool {
-		return a[i] < a[j]
-	})
-	return a
 }

--- a/cmd/coco/generate/findvaluefiles_test.go
+++ b/cmd/coco/generate/findvaluefiles_test.go
@@ -55,14 +55,14 @@ k33: v33
 type: environment
 name: name1
 values: 
-  - file1
-  - file2
+  - file1.yaml
+  - file2.yaml
 `),
 			"values/env2/coco.yaml": []byte(`
 type: environment
 name: name2
 values: 
-  - file3
+  - file3.yaml
 `),
 		},
 		wantFiles: map[string][]byte{
@@ -79,7 +79,7 @@ k33: v33
 		wantErr: nil,
 	},
 	{
-		title:          "working general example",
+		title:          "working general example with different values directories",
 		includeFilters: []string{"${BASEPATH}/values/", "${BASEPATH}/values2/"},
 		excludeFilters: []string{".tmpl"},
 		files: map[string][]byte{
@@ -103,14 +103,14 @@ k33: v33
 type: environment
 name: name1
 values: 
-  - file1
-  - file2
+  - file1.yaml
+  - file2.yaml
 `),
 			"values2/env/coco.yaml": []byte(`
 type: environment
 name: name2
 values: 
-  - file3
+  - file3.yaml
 `),
 		},
 		wantFiles: map[string][]byte{

--- a/cmd/coco/generate/generate.go
+++ b/cmd/coco/generate/generate.go
@@ -27,7 +27,7 @@ var (
 //   - takeControl: overwrite to do file generation also on files that have a different version
 //   - logLvl: specifies the log level that will be used
 func Generate(
-	basepath, templateIdentifier, persistenceFlag string,
+	basepath, templateIdentifier, persistenceFlag, configFileName string,
 	v *version.Version,
 	clusterValues, envFilters, folderFilters, excludeFolders []string,
 	logLvl log.Level, takeControl bool,
@@ -39,6 +39,7 @@ func Generate(
 
 	vals, err := readValueFiles(
 		basepath,
+		configFileName,
 		clusterValues,
 		envFilters,
 		[]string{templateIdentifier},

--- a/cmd/coco/generate/generate_test.go
+++ b/cmd/coco/generate/generate_test.go
@@ -18,6 +18,7 @@ import (
 type scenarioGenerate struct {
 	title          string
 	tmplIdentifier string
+	configFileName string
 	valueFilters   []string
 	envFilters     []string
 	folderFilters  []string
@@ -38,6 +39,7 @@ var scenariosGenerate = []scenarioGenerate{
 	{
 		title:          "simple test",
 		tmplIdentifier: ".tmpl",
+		configFileName: "coco.yaml",
 		valueFilters:   []string{"values"},
 		envFilters:     []string{},
 		folderFilters:  []string{},
@@ -52,12 +54,24 @@ parse:
 `),
 		},
 		values: map[string][]byte{
-			"values/c1": []byte(`
+			"values/c1/coco.yaml": []byte(`
+type: environment
+name: c1
+values:
+  - v1
+`),
+			"values/c2/coco.yaml": []byte(`
+type: environment
+name: c2
+values:
+  - v1
+`),
+			"values/c1/v1.yaml": []byte(`
 value1: v1
 value2: v2
 ifKey: parse
 `),
-			"values/c2": []byte(`value1: v22`),
+			"values/c2/v1.yaml": []byte(`value1: v22`),
 		},
 		logs: []logItem{},
 		want: map[string]want{
@@ -85,6 +99,7 @@ ifKey: parse
 	{
 		title:          "test error",
 		tmplIdentifier: ".tmpl",
+		configFileName: "coco.yaml",
 		valueFilters:   []string{"values"},
 		envFilters:     []string{},
 		folderFilters:  []string{},
@@ -92,7 +107,13 @@ ifKey: parse
 			"services/a/.tmpl": []byte(`key: {`),
 		},
 		values: map[string][]byte{
-			"values/c1": []byte(`value1: fromValues-1`),
+			"values/coco.yaml": []byte(`
+type: environment
+name: values
+values: 
+  - c1
+`),
+			"values/c1.yaml": []byte(`value1: fromValues-1`),
 		},
 		logs: []logItem{
 			{
@@ -112,7 +133,7 @@ ifKey: parse
 					},
 				},
 				vals: map[string]interface{}{
-					"c1": map[string]interface{}{"value1": "fromValues-1"},
+					"values": map[string]interface{}{"value1": "fromValues-1"},
 				},
 			},
 		},
@@ -121,6 +142,7 @@ ifKey: parse
 	{
 		title:          "test template does not exist error",
 		tmplIdentifier: ".tmpl",
+		configFileName: "coco.yaml",
 		valueFilters:   []string{"values"},
 		envFilters:     []string{},
 		folderFilters:  []string{},
@@ -128,11 +150,126 @@ ifKey: parse
 			"services/a/.tmpl": []byte(`key: {`),
 		},
 		values: map[string][]byte{
-			"values/c1": []byte(`value1: fromValues-1`),
+			"values/coco.yaml": []byte(`
+type: environment
+values:
+  - c1`),
+			"values/c1.yaml": []byte(`value1: fromValues-1`),
 		},
 		logs:    []logItem{},
 		want:    map[string]want{},
 		wantErr: errors.New("lstat : no such file or directory"),
+	},
+	{
+		title:          "template folder",
+		tmplIdentifier: ".tmpl",
+		configFileName: "coco.yaml",
+		valueFilters:   []string{"values"},
+		envFilters:     nil,
+		folderFilters:  nil,
+		exclFilters:    nil,
+		logs:           nil,
+		want: map[string]want{
+			"services/a": {
+				tmpls: []template{
+					{
+						source:     "services/a/.tmpl/template1.yaml",
+						basepath:   "services/a",
+						namePrefix: "",
+						subpath:    "/template1.yaml",
+					},
+					{
+						source:     "services/a/.tmpl/template2.yaml",
+						basepath:   "services/a",
+						namePrefix: "",
+						subpath:    "/template2.yaml",
+					},
+				},
+				vals: map[string]interface{}{
+					"env1": map[string]interface{}{
+						"test":  "v1",
+						"test2": "v2",
+					},
+				},
+			},
+		},
+		wantErr: nil,
+		templates: map[string][]byte{
+			"services/a/.tmpl/template1.yaml": []byte(`
+test: {{.test}}`),
+			"services/a/.tmpl/template2.yaml": []byte(`
+test2: {{.test2}}`),
+		},
+		values: map[string][]byte{
+			"services/a/values/coco.yaml": []byte(`
+type: environment
+name: env1
+values: 
+  - value1`),
+			"services/a/values/value1.yaml": []byte(`
+test: v1
+test2: v2`),
+		},
+	},
+	{
+		title:          "relative path and value overwriting test",
+		tmplIdentifier: ".tmpl",
+		configFileName: "coco.yaml",
+		valueFilters:   []string{"values"},
+		envFilters:     []string{},
+		folderFilters:  []string{},
+		templates: map[string][]byte{
+			"services/a/.tmpl": []byte(`
+keyInParentFolder: {{.value1}}
+keyInSubfolder: {{.value2}}
+keyInBothFolders: {{.value3}}
+`),
+		},
+		values: map[string][]byte{
+			"values/c1/coco.yaml": []byte(`
+type: environment
+name: c1
+values:
+  - v1
+`),
+			"values/c1/c2/coco.yaml": []byte(`
+type: environment
+name: c2
+values:
+  - ../v1
+  - v1
+`),
+			"values/c1/v1.yaml": []byte(`
+keyInParentFolder: v1
+keyInBothFolders: v2
+`),
+			"values/c1/c2/v1.yaml": []byte(`
+keyInSubfolder: v3
+keyInBothFolders: v22
+`),
+		},
+		logs: []logItem{},
+		want: map[string]want{
+			"services/a": {
+				tmpls: []template{
+					{
+						source:     "services/a/.tmpl",
+						basepath:   "services/a",
+						namePrefix: "",
+						subpath:    "",
+					},
+				},
+				vals: map[string]interface{}{
+					"c1": map[string]interface{}{
+						"keyInParentFolder": "v1", "keyInBothFolders": "v2",
+					},
+					"c2": map[string]interface{}{
+						"keyInParentFolder": "v1", "keyInBothFolders": "v22", "keyInSubfolder": "v3",
+					},
+				},
+			},
+		},
+		wantErr: nil,
 	},
 }
 
@@ -178,6 +315,7 @@ func (s *scenarioGenerate) Test(t *testing.T) {
 		tmpDir,
 		s.tmplIdentifier,
 		"irrelevant",
+		s.configFileName,
 		&version.Version{},
 		s.valueFilters,
 		s.envFilters,

--- a/cmd/coco/generate/generate_test.go
+++ b/cmd/coco/generate/generate_test.go
@@ -58,13 +58,13 @@ parse:
 type: environment
 name: c1
 values:
-  - v1
+  - v1.yaml
 `),
 			"values/c2/coco.yaml": []byte(`
 type: environment
 name: c2
 values:
-  - v1
+  - v1.yaml
 `),
 			"values/c1/v1.yaml": []byte(`
 value1: v1
@@ -111,7 +111,7 @@ ifKey: parse
 type: environment
 name: values
 values: 
-  - c1
+  - c1.yaml
 `),
 			"values/c1.yaml": []byte(`value1: fromValues-1`),
 		},
@@ -153,7 +153,7 @@ values:
 			"values/coco.yaml": []byte(`
 type: environment
 values:
-  - c1`),
+  - c1.yaml`),
 			"values/c1.yaml": []byte(`value1: fromValues-1`),
 		},
 		logs:    []logItem{},
@@ -205,7 +205,7 @@ test2: {{.test2}}`),
 type: environment
 name: env1
 values: 
-  - value1`),
+  - value1.yaml`),
 			"services/a/values/value1.yaml": []byte(`
 test: v1
 test2: v2`),
@@ -230,14 +230,14 @@ keyInBothFolders: {{.value3}}
 type: environment
 name: c1
 values:
-  - v1
+  - v1.yaml
 `),
 			"values/c1/c2/coco.yaml": []byte(`
 type: environment
 name: c2
 values:
-  - ../v1
-  - v1
+  - ../v1.yaml
+  - v1.yaml
 `),
 			"values/c1/v1.yaml": []byte(`
 keyInParentFolder: v1

--- a/cmd/coco/generate/readme.md
+++ b/cmd/coco/generate/readme.md
@@ -82,21 +82,22 @@ following features:
 ### How it works
 
 In general, the file generation command depends on a set of global inputs (the
-files in the top-level `values` folder). 
-For each values file to be generated there needs to be a folder with the desired name. 
-Within the folder should be a `coco.yaml` configuration file, with the following structure: 
-```file 
+files in the top-level `values` folder). For each values file to be generated
+there needs to be a folder with the desired name. Within the folder should be a
+`coco.yaml` configuration file, with the following structure:
+
+```file
 type: environment
-values: 
+values:
   - names of value.yaml files
   - with path relative to coco.yaml
-``` 
-The value files need to be `.yaml` files, 
-however in the list the file ending must not be provided. 
-These input files govern which files
-will be generated and what values are generated automatically.
-Note that all keys will be merged and if multiple value files contain the same key, 
-the values lower in the list overwrite previous values.
+```
+
+The value files need to be `.yaml` files, however in the list the file ending
+must not be provided. These input files govern which files will be generated and
+what values are generated automatically. Note that all keys will be merged and
+if multiple value files contain the same key, the values lower in the list
+overwrite previous values.
 
 ### Naming rules
 
@@ -306,6 +307,7 @@ After file-generation, this gives the following folders
 where we droped the remaining files for brevity.
 
 ### Example subfolder, relative path, merging and overwriting of values
+
 ### Setup
 
 ```file
@@ -329,7 +331,9 @@ The value file in the cluster_1 folder contains the following keys and values:
 generalValue: generalValue
 parentValue: parentValue
 ```
-With the coco.yaml file: 
+
+With the coco.yaml file:
+
 ```yaml
 type: environment
 name: parentFolderCluster
@@ -337,7 +341,7 @@ values:
   - value1
 ```
 
-Whereas the values file in the subfolder look like this: 
+Whereas the values file in the subfolder look like this:
 
 ```yaml
 generalValue: specificValue
@@ -345,6 +349,7 @@ subValue: subValue
 ```
 
 With the coco.yaml file:
+
 ```yaml
 type: environment
 name: subfolderCluster
@@ -379,18 +384,22 @@ subValue: {{ .subValue }}
 |   |   |   +-- coco.yaml
 |   |   |   +-- value2.yaml
 ```
- Where 'parentFolderCluster.yaml' contains these key-value pairs:
- ```yaml
+
+Where 'parentFolderCluster.yaml' contains these key-value pairs:
+
+```yaml
 generalValue: generalValue
 parentValue: parentValue
 ```
 
-Whereas  'subfolderCluster.yaml' looks like this: 
+Whereas 'subfolderCluster.yaml' looks like this:
+
 ```yaml
 generalValue: specificValue
 parentValue: parentValue
 subValue: subValue
 ```
 
-Note that the value2 key 'generalValue' overwrites the corresponding key from 'value1'
-since it is listed below in '/values/cluster_1/cluster_2/coco.yaml' and still inherits the 'parentValue.
+Note that the value2 key 'generalValue' overwrites the corresponding key from
+'value1' since it is listed below in '/values/cluster_1/cluster_2/coco.yaml' and
+still inherits the 'parentValue.

--- a/cmd/coco/inputfile/inputfile.go
+++ b/cmd/coco/inputfile/inputfile.go
@@ -55,7 +55,9 @@ func Load(file string) (Coco, error) {
 	return res, nil
 }
 
-func FindAll(basepath, configFileName string, includeOr, includeAnd, exclude []string) (map[string]files.File, error) {
+func FindAll(
+	basepath, configFileName string, includeOr, includeAnd, exclude []string,
+) (map[string]files.File, error) {
 	includeAnd = append(includeAnd, configFileName)
 	fileRunner := files.New(basepath).
 		Include(files.OR, includeOr).

--- a/cmd/coco/inputfile/inputfile.go
+++ b/cmd/coco/inputfile/inputfile.go
@@ -14,9 +14,9 @@ import (
 //nolint:lll // no linebreaks available for struct tags
 type Coco struct {
 	Type         ConfigType `yaml:"type" doc:"msg=type of the configuration file,req,o=environment,o=component"`
-	Values       []string   `yaml:"values" doc:"msg=list of .yaml files relative to the config file without file ending, opt,"`
+	Values       []string   `yaml:"values" doc:"msg=list relative paths to config files, req=for environments only"`
 	Name         string     `yaml:"name" doc:"msg=name of component or environment,req"`
-	Dependencies []string   `yaml:"dependencies" doc:"msg=list of dependencies, opt"`
+	Dependencies []string   `yaml:"dependencies" doc:"msg=list of components that this component depends on, req=for components only"`
 }
 
 // Types of config files.

--- a/cmd/coco/inputfile/inputfile.go
+++ b/cmd/coco/inputfile/inputfile.go
@@ -1,0 +1,78 @@
+package inputfile
+
+import (
+	"fmt"
+
+	"github.com/SAP/configuration-tools-for-gitops/pkg/files"
+	"github.com/SAP/configuration-tools-for-gitops/pkg/maputils"
+	"gopkg.in/yaml.v3"
+)
+
+// Coco struct contains keys for both components and environments.
+// Unused fields are set nil by the unmarshal function
+//
+//nolint:lll // no linebreaks available for struct tags
+type Coco struct {
+	Type         ConfigType `yaml:"type" doc:"msg=type of the configuration file,req,o=environment,o=component"`
+	Values       []string   `yaml:"values" doc:"msg=list of .yaml files relative to the config file without file ending, opt,"`
+	Name         string     `yaml:"name" doc:"msg=name of component or environment,req"`
+	Dependencies []string   `yaml:"dependencies" doc:"msg=list of dependencies, opt"`
+}
+
+// Types of config files.
+// Needs to be maintained manually together with the corresponding check functions.
+type ConfigType string
+
+const (
+	COMPONENT   ConfigType = "component"
+	ENVIRONMENT ConfigType = "environment"
+)
+
+var AllConfigTypes = map[ConfigType]bool{COMPONENT: true, ENVIRONMENT: true}
+
+// Receives a file path and reads the byte content into a Coco struct
+// File should be a yaml containing at least a valid type key
+func Load(file string) (Coco, error) {
+	content, err := files.Read(file)
+	if err != nil {
+		return Coco{}, err
+	}
+	res := Coco{}
+	err = yaml.Unmarshal(content, &res)
+	if err != nil {
+		return Coco{}, err
+	}
+
+	if _, ok := AllConfigTypes[res.Type]; !ok {
+		allConfigTypesOrdered := maputils.KeysSorted(AllConfigTypes)
+
+		return Coco{}, fmt.Errorf(
+			"unsupported type: %q, available options: %+v",
+			res.Type,
+			allConfigTypesOrdered,
+		)
+	}
+	return res, nil
+}
+
+func FindAll(basepath, configFileName string, includeOr, includeAnd, exclude []string) (map[string]files.File, error) {
+	includeAnd = append(includeAnd, configFileName)
+	fileRunner := files.New(basepath).
+		Include(files.OR, includeOr).
+		Include(files.AND, includeAnd).
+		Exclude(files.OR, exclude).
+		ReadContent()
+	vFiles, err := fileRunner.Execute()
+	if err != nil {
+		return nil, err
+	}
+	return vFiles.Content(), nil
+}
+
+func (c *Coco) IsComponent() bool {
+	return c.Type == COMPONENT
+}
+
+func (c *Coco) IsEnvironment() bool {
+	return c.Type == ENVIRONMENT
+}

--- a/cmd/coco/inputfile/inputfile_test.go
+++ b/cmd/coco/inputfile/inputfile_test.go
@@ -1,0 +1,238 @@
+package inputfile
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/SAP/configuration-tools-for-gitops/pkg/log"
+	"github.com/SAP/configuration-tools-for-gitops/pkg/maputils"
+	"github.com/SAP/configuration-tools-for-gitops/pkg/testfuncs"
+	"go.uber.org/zap"
+)
+
+type inputfile struct {
+	title   string
+	input   map[string][]byte
+	want    []Coco
+	wantErr error
+}
+
+type inputFindAll struct {
+	title            string
+	configFileName   string
+	input            map[string][]byte
+	includeOrFilters []string
+	includeAndFilter []string
+	excludeFilter    []string
+	want             map[string][]byte
+	wantErr          error
+}
+
+var inputfiles = []inputfile{
+	{
+		title: "General working example for environment",
+		input: map[string][]byte{
+			"coco": []byte(`
+type: environment
+name: name1
+values:
+  - file1
+  - file2
+`),
+		},
+		want: []Coco{
+			{
+				Type:   ENVIRONMENT,
+				Name:   "name1",
+				Values: []string{"file1", "file2"},
+			},
+		},
+		wantErr: nil,
+	},
+	{
+		title: "General working example for component",
+		input: map[string][]byte{
+			"coco": []byte(`
+type: component
+name: component1
+dependencies:
+  - dep1
+  - dep2
+`),
+		},
+		want: []Coco{
+			{
+				Type:         COMPONENT,
+				Name:         "component1",
+				Dependencies: []string{"dep1", "dep2"},
+			},
+		},
+		wantErr: nil,
+	},
+	{
+		title: "Unsupported type",
+		input: map[string][]byte{
+			"coco.yaml": []byte(`
+type: unsupportedType
+`),
+		},
+		want: []Coco{{}},
+		wantErr: fmt.Errorf(
+			"unsupported type: %q, available options: %+v",
+			"unsupportedType",
+			maputils.KeysSorted(AllConfigTypes),
+		),
+	},
+}
+
+var inputsFindAll = []inputFindAll{
+	{
+		title:          "general working examples with different config types and default configFileName",
+		configFileName: "coco.yaml",
+		input: map[string][]byte{
+			"values/env1/coco.yaml": []byte(`
+type: environment
+name: env1
+values: 
+  - v1
+  - v11`),
+			"values/env2/coco.yaml": []byte(`
+type: environment
+name: env2
+values: 
+  - v2
+  - v22`),
+			"dependencies/coco.yaml": []byte(`
+type: component
+name: comp1
+dependencies:
+  - dep1
+`),
+		},
+		includeOrFilters: nil,
+		includeAndFilter: nil,
+		excludeFilter:    nil,
+		want: map[string][]byte{
+			"/values/env1/coco.yaml": []byte(`
+type: environment
+name: env1
+values: 
+  - v1
+  - v11`),
+			"/values/env2/coco.yaml": []byte(`
+type: environment
+name: env2
+values: 
+  - v2
+  - v22`),
+			"/dependencies/coco.yaml": []byte(`
+type: component
+name: comp1
+dependencies:
+  - dep1
+`),
+		},
+		wantErr: nil,
+	},
+	{
+		title:          "general working example including only specified configFileNames",
+		configFileName: "custom.yaml",
+		input: map[string][]byte{
+			"values/env1/coco.yaml": []byte(`
+type: environment
+name: env1
+values: 
+  - v1
+  - v11`),
+			"values/env2/custom.yaml": []byte(`
+type: environment
+name: env2
+values: 
+  - v2
+  - v22`),
+			"dependencies/coco.yaml": []byte(`
+type: component
+name: comp1
+dependencies:
+  - dep1
+`),
+		},
+		includeOrFilters: nil,
+		includeAndFilter: nil,
+		excludeFilter:    nil,
+		want: map[string][]byte{
+			"/values/env2/custom.yaml": []byte(`
+type: environment
+name: env2
+values: 
+  - v2
+  - v22`),
+		},
+		wantErr: nil,
+	},
+}
+
+func TestInputfile(t *testing.T) {
+	if err := log.Init(log.Debug(), "", true); err != nil {
+		zap.S().Fatal(err)
+	}
+	for _, i := range inputfiles {
+		t.Logf("test scenario: %s\n", i.title)
+		i.Test(t)
+	}
+	for _, i := range inputsFindAll {
+		t.Logf("test scenario: %s\n", i.title)
+		i.FindTest(t)
+	}
+}
+
+func (i *inputFindAll) FindTest(t *testing.T) {
+	td, err := testfuncs.PrepareTestDirTree(i.input)
+	if err != nil {
+		t.Logf("unable to create test dir tree: %v\n", err)
+		t.FailNow()
+	}
+	defer td.Cleanup(t)
+	tmpDir := td.Path()
+	files, err := FindAll(tmpDir, i.configFileName, i.includeOrFilters, i.includeAndFilter, i.excludeFilter)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	var res = map[string][]byte{}
+	for p, v := range files {
+		res[strings.Replace(p, tmpDir, "", 1)] = v.Content
+	}
+	if !reflect.DeepEqual(res, i.want) {
+		t.Errorf("results do not match: \nwant = \"%+v\"\ngot =  \"%+v\"",
+			i.want,
+			res,
+		)
+		t.Fail()
+	}
+}
+
+func (i inputfile) Test(t *testing.T) {
+	td, err := testfuncs.PrepareTestDirTree(i.input)
+	if err != nil {
+		t.Logf("unable to create test dir tree: %v\n", err)
+		t.FailNow()
+	}
+	defer td.Cleanup(t)
+	tmpDir := td.Path()
+	var cocoStructs []Coco
+	for filename := range i.input {
+		coco, err := Load(tmpDir + "/" + filename)
+		testfuncs.CheckErrs(t, i.wantErr, err)
+		cocoStructs = append(cocoStructs, coco)
+	}
+	if !reflect.DeepEqual(cocoStructs, i.want) {
+		t.Errorf("results do not match: \nwant = \"%+v\"\ngot =  \"%+v\"",
+			i.want,
+			cocoStructs,
+		)
+		t.Fail()
+	}
+}

--- a/cmd/coco/inputfile/inputfile_test.go
+++ b/cmd/coco/inputfile/inputfile_test.go
@@ -174,21 +174,27 @@ values:
 	},
 }
 
-func TestInputfile(t *testing.T) {
+func TestFindAll(t *testing.T) {
+	if err := log.Init(log.Debug(), "", true); err != nil {
+		zap.S().Fatal(err)
+	}
+	for _, i := range inputsFindAll {
+		t.Logf("test scenario: %s\n", i.title)
+		i.findAll(t)
+	}
+}
+
+func TestLoad(t *testing.T) {
 	if err := log.Init(log.Debug(), "", true); err != nil {
 		zap.S().Fatal(err)
 	}
 	for _, i := range inputfiles {
 		t.Logf("test scenario: %s\n", i.title)
-		i.Test(t)
-	}
-	for _, i := range inputsFindAll {
-		t.Logf("test scenario: %s\n", i.title)
-		i.FindTest(t)
+		i.load(t)
 	}
 }
 
-func (i *inputFindAll) FindTest(t *testing.T) {
+func (i *inputFindAll) findAll(t *testing.T) {
 	td, err := testfuncs.PrepareTestDirTree(i.input)
 	if err != nil {
 		t.Logf("unable to create test dir tree: %v\n", err)
@@ -214,7 +220,7 @@ func (i *inputFindAll) FindTest(t *testing.T) {
 	}
 }
 
-func (i inputfile) Test(t *testing.T) {
+func (i inputfile) load(t *testing.T) {
 	td, err := testfuncs.PrepareTestDirTree(i.input)
 	if err != nil {
 		t.Logf("unable to create test dir tree: %v\n", err)

--- a/cmd/coco/inputfile/inputfile_test.go
+++ b/cmd/coco/inputfile/inputfile_test.go
@@ -96,14 +96,14 @@ var inputsFindAll = []inputFindAll{
 type: environment
 name: env1
 values: 
-  - v1
-  - v11`),
+  - v1.yaml
+  - v11.yaml`),
 			"values/env2/coco.yaml": []byte(`
 type: environment
 name: env2
 values: 
-  - v2
-  - v22`),
+  - v2.yaml
+  - v22.yaml`),
 			"dependencies/coco.yaml": []byte(`
 type: component
 name: comp1
@@ -119,14 +119,14 @@ dependencies:
 type: environment
 name: env1
 values: 
-  - v1
-  - v11`),
+  - v1.yaml
+  - v11.yaml`),
 			"/values/env2/coco.yaml": []byte(`
 type: environment
 name: env2
 values: 
-  - v2
-  - v22`),
+  - v2.yaml
+  - v22.yaml`),
 			"/dependencies/coco.yaml": []byte(`
 type: component
 name: comp1
@@ -144,14 +144,14 @@ dependencies:
 type: environment
 name: env1
 values: 
-  - v1
-  - v11`),
+  - v1.yaml
+  - v11.yaml`),
 			"values/env2/custom.yaml": []byte(`
 type: environment
 name: env2
 values: 
-  - v2
-  - v22`),
+  - v2.yaml
+  - v22.yaml`),
 			"dependencies/coco.yaml": []byte(`
 type: component
 name: comp1
@@ -167,8 +167,8 @@ dependencies:
 type: environment
 name: env2
 values: 
-  - v2
-  - v22`),
+  - v2.yaml
+  - v22.yaml`),
 		},
 		wantErr: nil,
 	},

--- a/cmd/coco/inputfile/readme.md
+++ b/cmd/coco/inputfile/readme.md
@@ -1,0 +1,19 @@
+# Inputfile parsing
+
+This package reads content of configuration files ('coco.yaml' if not otherwise specified) that are identified with a path.
+
+Here is an example for inspecting the general structure and usage of config files
+```bash
+coco inspect values
+```
+Sample output: (Note: the output might differ due to modifications in the codebase)
+
+```file
+dependencies: list of dependencies ([]string)
+name: name of component or environment (string) REQUIRED
+type: type of the configuration file (string, options:[environment,component]) REQUIRED
+values: list of .yaml files relative to the config file without file ending ([]string)
+```
+
+Both contents will be loaded in a `Coco` struct for the `Load` function to be independent of the content.
+Unused values of the `Coco` struct will be nil.

--- a/cmd/coco/inputfile/readme.md
+++ b/cmd/coco/inputfile/readme.md
@@ -1,12 +1,16 @@
 # Inputfile parsing
 
-This package reads content of configuration files ('coco.yaml' if not otherwise specified) that are identified with a path.
+This package deals with configuration files ('coco.yaml' if not otherwise
+specified) that are identified within the basepath.
 
-Here is an example for inspecting the general structure and usage of config files
+All possible inputs for configuration files can be obtained by running
+
 ```bash
 coco inspect values
 ```
-Sample output: (Note: the output might differ due to modifications in the codebase)
+
+Sample output: (Note: the output might differ due to modifications in the
+codebase)
 
 ```file
 dependencies: list of dependencies ([]string)
@@ -14,6 +18,3 @@ name: name of component or environment (string) REQUIRED
 type: type of the configuration file (string, options:[environment,component]) REQUIRED
 values: list of .yaml files relative to the config file without file ending ([]string)
 ```
-
-Both contents will be loaded in a `Coco` struct for the `Load` function to be independent of the content.
-Unused values of the `Coco` struct will be nil.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869
 	go.uber.org/zap v1.24.0
+	golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb
 	golang.org/x/oauth2 v0.9.0
 	golang.org/x/sys v0.9.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -21,7 +22,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20230619160724-3fbb1f12458c // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20230626094100-7e9e0395ebec // indirect
 	github.com/acomagu/bufpipe v1.0.4 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
@@ -61,7 +62,7 @@ require (
 	golang.org/x/text v0.10.0 // indirect
 	golang.org/x/tools v0.10.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
-github.com/ProtonMail/go-crypto v0.0.0-20230619160724-3fbb1f12458c h1:figwFwYep1Qnl64Y+Rc8tyQWE0xvYAN+5EX+rD40pTU=
-github.com/ProtonMail/go-crypto v0.0.0-20230619160724-3fbb1f12458c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
+github.com/ProtonMail/go-crypto v0.0.0-20230626094100-7e9e0395ebec h1:vV3RryLxt42+ZIVOFbYJCH1jsZNTNmj2NYru5zfx+4E=
+github.com/ProtonMail/go-crypto v0.0.0-20230626094100-7e9e0395ebec/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
@@ -293,6 +293,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb h1:xIApU0ow1zwMa2uL1VDNeQlNVFTWMQxZUZCMDy0Q4Us=
+golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -598,8 +600,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
-google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/maputils/maputils.go
+++ b/pkg/maputils/maputils.go
@@ -1,0 +1,20 @@
+package maputils
+
+import (
+	"github.com/SAP/configuration-tools-for-gitops/pkg/sliceutils"
+	"golang.org/x/exp/constraints"
+)
+
+func Keys[K comparable, V any](m map[K]V) []K {
+	res := make([]K, 0, len(m))
+	for k := range m {
+		res = append(res, k)
+	}
+	return res
+}
+
+func KeysSorted[K constraints.Ordered, V any](m map[K]V) []K {
+	res := Keys(m)
+	sliceutils.Sort(res)
+	return res
+}

--- a/pkg/sliceutils/sort.go
+++ b/pkg/sliceutils/sort.go
@@ -1,0 +1,13 @@
+package sliceutils
+
+import (
+	"sort"
+
+	"golang.org/x/exp/constraints"
+)
+
+func Sort[T constraints.Ordered](s []T) {
+	sort.Slice(s, func(i, j int) bool {
+		return s[i] < s[j]
+	})
+}

--- a/pkg/yamlfile/docs.go
+++ b/pkg/yamlfile/docs.go
@@ -1,0 +1,185 @@
+package yamlfile
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+const (
+	valuesTag = "doc"
+	keyTag    = "yaml"
+)
+
+// DocOutput constructs a documentation interface from the provided struct by
+// using the struct field types as well as the information given in the "doc" struct
+// tag. In the doc tag the following information can be given in a comma-separated list:
+//
+//   - msg: describing message
+//   - default: default value
+//   - req: required field
+//   - option,o: 1 possible value (multiple values are specified by multiple occurrences)
+//
+// e.g.: `doc:"msg=this is my message,default=0,o=0, o=1, req"`. If no "doc"
+// tag is present the field will be ignored. The output format is map[string]interface{},
+// where the interface is either a doc-string or a substructure of the same format.
+func DocOutput(s interface{}) interface{} {
+	return parseNode(reflect.TypeOf(s))
+}
+
+func parseNode(t reflect.Type) interface{} {
+	switch t.Kind() {
+	case reflect.Ptr:
+		return parseNode(t.Elem())
+	case reflect.Struct:
+		return parseStruct(t)
+	case reflect.Array, reflect.Slice:
+		return parseSlice(t)
+	case reflect.Map:
+		return parseMap(t)
+	default:
+		return parsePrimitive(t)
+	}
+}
+
+func parseMap(t reflect.Type) interface{} {
+	tV := parseNode(t.Elem())
+
+	return map[string]interface{}{str(t.Key()): tV}
+}
+
+func parseSlice(t reflect.Type) interface{} {
+	tV := parseNode(t.Elem())
+	return []interface{}{tV}
+}
+
+func parsePrimitive(t reflect.Type) interface{} {
+	return fmt.Sprintf("(%v)", findType(t))
+}
+
+func parseStruct(t reflect.Type) interface{} {
+	res := map[string]interface{}{}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tKind := findType(field.Type)
+
+		vTag, ok := field.Tag.Lookup(valuesTag)
+		if vTag == "-" {
+			continue
+		}
+		key := structKeyName(&field)
+		if ok {
+			res[key] = docFromTag(vTag, str(field.Type))
+			continue
+		}
+		switch tKind {
+		case reflect.Struct:
+			subStruct := parseNode(field.Type)
+
+			if !reflect.DeepEqual(subStruct, map[string]interface{}{}) {
+				res[key] = subStruct
+			}
+		case reflect.Array, reflect.Slice:
+			subStruct := parseNode(field.Type)
+			if !reflect.DeepEqual(subStruct, []interface{}{}) {
+				res[key] = subStruct
+			}
+		case reflect.Map:
+			subStruct := parseNode(field.Type)
+			if !reflect.DeepEqual(subStruct, []interface{}{}) {
+				res[key] = subStruct
+			}
+		default:
+			res[key] = docFromTag(vTag, str(field.Type))
+		}
+	}
+	return res
+}
+
+func str(t reflect.Type) string {
+	switch t.Kind() {
+	case reflect.Ptr:
+		return str(t.Elem())
+	case reflect.Map:
+		return fmt.Sprintf("map[%s]%s", str(t.Key()), str(t.Elem()))
+	case reflect.Array, reflect.Slice:
+		return fmt.Sprintf("[]%s", str(t.Elem()))
+	default:
+		return t.Kind().String()
+	}
+}
+
+func findType(raw reflect.Type) reflect.Kind {
+	var t reflect.Kind
+	switch raw.Kind() {
+	case reflect.Ptr:
+		t = raw.Elem().Kind()
+	default:
+		t = raw.Kind()
+	}
+	return t
+}
+
+func structKeyName(f *reflect.StructField) string {
+	name := f.Tag.Get(keyTag)
+	if name == "" || name == "-" {
+		name = f.Name
+	}
+	return strings.TrimSuffix(name, ",omitempty")
+}
+func docFromTag(tag, typeVal string) string {
+	tags := strings.Split(tag, ",")
+	var msg, reqVal, defaultVal string
+	optionsSlice := []string{}
+	required := false
+
+	for _, raw := range tags {
+		t := strings.TrimSpace(raw)
+		kv := strings.Split(t, "=")
+		if len(kv) == 0 {
+			continue
+		}
+		if len(kv) == 1 && kv[0] == "req" {
+			required = true
+			continue
+		}
+		switch kv[0] {
+		case "msg":
+			msg = kv[1]
+		case "default":
+			defaultVal = fmt.Sprintf("default:%q", kv[1])
+		case "req":
+			reqVal = kv[1]
+		case "option", "o":
+			optionsSlice = append(optionsSlice, kv[1])
+		}
+	}
+	options := ""
+	if len(optionsSlice) > 0 {
+		options = fmt.Sprintf("options:[%v]", strings.Join(optionsSlice, ","))
+	}
+	info := fmt.Sprintf("(%v)", strings.Join(appendNonEmpty(
+		[]string{}, typeVal, defaultVal, options,
+	), ", "))
+	var req string
+	if reqVal != "" {
+		req = fmt.Sprintf("REQUIRED:%q", reqVal)
+	}
+	if required {
+		req = "REQUIRED"
+	}
+
+	return strings.Join(appendNonEmpty([]string{}, msg, info, req), " ")
+}
+
+func appendNonEmpty(s []string, els ...string) []string {
+	res := make([]string, 0, len(s))
+	_ = copy(res, s)
+	for _, e := range els {
+		if e == "" {
+			continue
+		}
+		res = append(res, e)
+	}
+	return res
+}

--- a/pkg/yamlfile/docs_test.go
+++ b/pkg/yamlfile/docs_test.go
@@ -1,0 +1,155 @@
+package yamlfile_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/SAP/configuration-tools-for-gitops/pkg/yamlfile"
+)
+
+type scenarioDoc struct {
+	title      string
+	input      interface{}
+	wantOutput interface{}
+}
+
+var scenariosDocs = []scenarioDoc{
+	{
+		title: "struct example",
+		input: struct {
+			Key1 string `doc:"msg=this is a description,default=hello"`
+			Key2 bool   `yaml:"custom_key" doc:"req"`
+			Key3 int    `doc:"req=by this"`
+			Key4 int    `doc:"o=0,o=1,req"`
+		}{},
+		wantOutput: map[string]interface{}{
+			"Key1":       `this is a description (string, default:"hello")`,
+			"Key3":       `(int) REQUIRED:"by this"`,
+			"custom_key": `(bool) REQUIRED`,
+			"Key4":       `(int, options:[0,1]) REQUIRED`,
+		},
+	},
+	{
+		title: "map example",
+		input: map[string]struct {
+			Key1 string `doc:"msg=this is a description,default=hello"`
+		}{},
+		wantOutput: map[string]interface{}{
+			"string": map[string]interface{}{
+				"Key1": `this is a description (string, default:"hello")`,
+			},
+		},
+	},
+	{
+		title: "slice example",
+		input: []struct {
+			Key1 string `doc:"msg=this is a description,default=hello"`
+		}{},
+		wantOutput: []interface{}{
+			map[string]interface{}{
+				"Key1": `this is a description (string, default:"hello")`,
+			},
+		},
+	},
+	{
+		title: "pointer example",
+		input: struct {
+			Key1 *string `doc:"msg=this is a description,default=hello"`
+			Key2 *struct {
+				A *map[string]string `doc:"msg=no deeper resolution"`
+			}
+			Key3 *[]struct {
+				B string
+				C []string `doc:"msg=no deeper resolution"`
+			}
+		}{},
+		wantOutput: map[string]interface{}{
+			"Key1": `this is a description (string, default:"hello")`,
+			"Key2": map[string]interface{}{"A": "no deeper resolution (map[string]string)"},
+			"Key3": []interface{}{map[string]interface{}{
+				"B": "(string)",
+				"C": "no deeper resolution ([]string)",
+			}},
+		},
+	},
+	{
+		title: "nested structs",
+		input: struct {
+			Root struct {
+				L11 string `doc:"req"`
+				L12 struct {
+					L2 string `doc:"req"`
+				}
+			}
+		}{},
+		wantOutput: map[string]interface{}{
+			"Root": map[string]interface {
+			}{
+				"L11": "(string) REQUIRED",
+				"L12": map[string]interface{}{
+					"L2": "(string) REQUIRED",
+				},
+			},
+		},
+	},
+	{
+		title: "nested map and slice",
+		input: struct {
+			Root struct {
+				Slice []struct {
+					S bool `doc:"req"`
+				}
+				Map map[string]struct{ M string }
+			}
+		}{},
+		wantOutput: map[string]interface{}{
+			"Root": map[string]interface {
+			}{
+				"Slice": []interface{}{map[string]interface{}{"S": "(bool) REQUIRED"}},
+				"Map": map[string]interface{}{
+					"string": map[string]interface{}{"M": "(string)"},
+				},
+			},
+		},
+	},
+	{
+		title: "ignore keys with doc tag -",
+		input: struct {
+			Key1       string `doc:"msg=this is a description,default=hello"`
+			NotIgnored string
+			Ignored    string `yaml:"ignored" doc:"-"`
+		}{},
+		wantOutput: map[string]interface{}{
+			"Key1":       `this is a description (string, default:"hello")`,
+			"NotIgnored": `(string)`,
+		},
+	},
+	{
+		title: "wrong doc string format",
+		input: struct {
+			Key1 string `doc:"irrelevant content,msg="`
+		}{},
+		wantOutput: map[string]interface{}{
+			"Key1": `(string)`,
+		},
+	},
+}
+
+func TestDocOutput(t *testing.T) {
+	for _, s := range scenariosDocs {
+		t.Logf("test scenario: %s\n", s.title)
+		res := yamlfile.DocOutput(s.input)
+		s.Check(t, res)
+	}
+}
+
+func (s *scenarioDoc) Check(t *testing.T, got interface{}) {
+	if !reflect.DeepEqual(s.wantOutput, got) {
+		t.Errorf(
+			"results do not match: \nwant = \"%+v\"\ngot =  \"%+v\"",
+			s.wantOutput,
+			got,
+		)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This feature allows multiple value files for the definition of environments that need to be grouped in one folder that also contains a configfile (default name: coco.yaml) specifying which value files to use.
This behaviour requires changes in the setup for the generate command and changes in the dependencies files in the target repositories.

Also some useful functionality regarding documentation, maps and arrays was added.