### PR TITLE
fix: (reconcxile) proper error handling on missing inputs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,12 @@ on:
     branches:
     - '**'
     - main
+    - v2
   pull_request:
     branches:
     - '**'
     - main
+    - v2
 # on: 
 #   push:
 #     tags:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: 
+      - "main"
+      - "v2"
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: 
+      - "main"
+      - "v2"
   schedule:
     - cron: '15 13 * * 2'
 

--- a/cmd/coco/commands/dependencies.go
+++ b/cmd/coco/commands/dependencies.go
@@ -1,13 +1,13 @@
 package commands
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/SAP/configuration-tools-for-gitops/v2/cmd/coco/dependencies"
 	"github.com/SAP/configuration-tools-for-gitops/v2/cmd/coco/graph"
-	"github.com/SAP/configuration-tools-for-gitops/v2/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -48,8 +48,7 @@ func newDependencies() *cobra.Command {
 			var ok bool
 			format, ok = graph.CastOutputFormat(rawFormat)
 			if !ok {
-				log.Sugar.Errorf("illegal format %q", rawFormat)
-				os.Exit(1)
+				failOnError(fmt.Errorf("illegal format %q", rawFormat), "dependencies")
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -65,16 +64,11 @@ func newDependencies() *cobra.Command {
 				overWriteGitDepth, // viper.GetInt(gitDepth),
 				logLvl,
 			)
-			if err != nil {
-				log.Sugar.Errorf("dependency failed with: %s", err)
-				os.Exit(1)
-			}
+			failOnError(err, "dependencies")
 
 			writeTo, err := writeTarget(viper.GetString(gitPathKey), outputFile)
-			if err != nil {
-				log.Sugar.Errorf("dependency failed with: %s", err)
-				os.Exit(1)
-			}
+			failOnError(err, "dependencies")
+
 			changedDeps.Print(writeTo, format)
 		},
 	}

--- a/cmd/coco/commands/generate.go
+++ b/cmd/coco/commands/generate.go
@@ -10,7 +10,6 @@ import (
 	"github.com/SAP/configuration-tools-for-gitops/v2/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
 )
 
 var (
@@ -42,23 +41,22 @@ in the gitops repository.
 		Run: func(cmd *cobra.Command, args []string) {
 			basepath := viper.GetString(gitPathKey)
 			configFileName := viper.GetString(componentCfg)
-			err := generate.Generate(
-				basepath,
-				tmplIdentifier,
-				persistenceFlag,
-				configFileName,
-				version.ReadAll(),
-				cleanValuePaths(valuesFolders, basepath),
-				environmentFilter,
-				args,
-				excludeFolders,
-				logLvl,
-				takeControl,
+			failOnError(
+				generate.Generate(
+					basepath,
+					tmplIdentifier,
+					persistenceFlag,
+					configFileName,
+					version.ReadAll(),
+					cleanValuePaths(valuesFolders, basepath),
+					environmentFilter,
+					args,
+					excludeFolders,
+					logLvl,
+					takeControl,
+				),
+				"generate",
 			)
-			if err != nil {
-				log.Sugar.Errorf("generate failed: %s", err)
-				os.Exit(1)
-			}
 		},
 	}
 
@@ -92,10 +90,10 @@ or the yaml tag "!HumanInput" will not be overwritten.`,
 		`if this flag is set, coco takes control over all generated files regardless
 of the version in the generated files`,
 	)
-	if err := c.Flags().MarkDeprecated("take-control", "please use \"--force\" instead"); err != nil {
-		zap.L().Sugar().Errorf("flag %q not found: %v", "take-control", err)
-		os.Exit(1)
-	}
+	failOnError(
+		c.Flags().MarkDeprecated("take-control", "please use \"--force\" instead"),
+		"generate",
+	)
 	c.Flags().BoolVar(
 		&takeControl, "force", false,
 		`if this flag is set, coco forcefully regenerats all files regardless of

--- a/cmd/coco/commands/generateCustom.go
+++ b/cmd/coco/commands/generateCustom.go
@@ -1,10 +1,9 @@
 package commands
 
 import (
-	"os"
+	"fmt"
 
 	"github.com/SAP/configuration-tools-for-gitops/v2/cmd/coco/generate"
-	"github.com/SAP/configuration-tools-for-gitops/v2/pkg/log"
 	"github.com/spf13/cobra"
 )
 
@@ -21,17 +20,18 @@ func newGenerateCustom() *cobra.Command {
 
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				log.Sugar.Errorf("no go-template provided, please provide a template as argument")
-				os.Exit(1)
+				failOnError(
+					fmt.Errorf("no go-template provided, please provide a template as argument"),
+					"custom",
+				)
 			}
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			err := generate.ParseTemplate(args[0], customValues, customTarget)
-			if err != nil {
-				log.Sugar.Errorf("generate failed: %s", err)
-				os.Exit(1)
-			}
+			failOnError(
+				generate.ParseTemplate(args[0], customValues, customTarget),
+				"custom",
+			)
 		},
 	}
 

--- a/cmd/coco/commands/graph.go
+++ b/cmd/coco/commands/graph.go
@@ -1,11 +1,11 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/SAP/configuration-tools-for-gitops/v2/cmd/coco/dependencies"
 	"github.com/SAP/configuration-tools-for-gitops/v2/cmd/coco/graph"
-	"github.com/SAP/configuration-tools-for-gitops/v2/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -27,8 +27,7 @@ func newGraph() *cobra.Command {
 			var ok bool
 			format, ok = graph.CastOutputFormat(rawFormat)
 			if !ok {
-				log.Sugar.Errorf("illegal format %q", rawFormat)
-				os.Exit(1)
+				failOnError(fmt.Errorf("illegal format %q", rawFormat), "graph")
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -36,10 +35,7 @@ func newGraph() *cobra.Command {
 				viper.GetString(gitPathKey),
 				viper.GetString(componentCfg),
 			)
-			if err != nil {
-				log.Sugar.Errorf("graph failed with: %s", err)
-				os.Exit(1)
-			}
+			failOnError(fmt.Errorf("graph failed with: %s", err), "graph")
 			deps.Print(os.Stdout, format)
 		},
 	}

--- a/cmd/coco/commands/root.go
+++ b/cmd/coco/commands/root.go
@@ -101,7 +101,7 @@ func newRoot() *cobra.Command {
 	)
 	bindFlag(c.PersistentFlags(), gitDepthKey, "git-depth", "GIT_DEPTH")
 
-	cobra.CheckErr(viper.BindEnv("git-token", "GITHUB_TOKEN"))
+	failOnError(viper.BindEnv("git-token", "GITHUB_TOKEN"), "root")
 
 	return c
 }

--- a/cmd/coco/commands/utils.go
+++ b/cmd/coco/commands/utils.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"os"
+
+	"github.com/SAP/configuration-tools-for-gitops/v2/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -9,4 +12,11 @@ import (
 func bindFlag(fs *pflag.FlagSet, key, flag, env string) {
 	cobra.CheckErr(viper.BindPFlag(key, fs.Lookup(flag)))
 	cobra.CheckErr(viper.BindEnv(key, env))
+}
+
+func failOnError(err error, command string) {
+	if err != nil {
+		log.Sugar.Errorf("failed in command %q: %v", command, err)
+		os.Exit(1)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/fatih/color v1.15.0
+	github.com/go-git/go-billy/v5 v5.4.1
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/google/go-github/v51 v51.0.0
 	github.com/spf13/cobra v1.7.0
@@ -28,7 +29,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.4.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect


### PR DESCRIPTION
Return proper errors when the `git.url` input is not set.