### PR TITLE
fix(generate): input value file merging

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,10 +13,10 @@ builds:
     ldflags:
       - -extldflags '-static'
       - -s -w 
-      - -X github.com/SAP/configuration-tools-for-gitops/pkg/version.version={{.Version}}
-      - -X github.com/SAP/configuration-tools-for-gitops/pkg/version.gitCommit={{.Commit}}
-      - -X github.com/SAP/configuration-tools-for-gitops/pkg/version.buildDate={{.Date}}
-      - -X github.com/SAP/configuration-tools-for-gitops/pkg/version.gitTreeState=clean
+      - -X github.com/SAP/configuration-tools-for-gitops/v2/pkg/version.version={{.Version}}
+      - -X github.com/SAP/configuration-tools-for-gitops/v2/pkg/version.gitCommit={{.Commit}}
+      - -X github.com/SAP/configuration-tools-for-gitops/v2/pkg/version.buildDate={{.Date}}
+      - -X github.com/SAP/configuration-tools-for-gitops/v2/pkg/version.gitTreeState=clean
 
 
 archives:

--- a/cmd/coco/generate/findvaluefiles_test.go
+++ b/cmd/coco/generate/findvaluefiles_test.go
@@ -77,6 +77,53 @@ k33: v33
 		wantErr: nil,
 	},
 	{
+		title:          "value overwrites",
+		includeFilters: []string{"${BASEPATH}/values/"},
+		excludeFilters: []string{".tmpl"},
+		files: map[string][]byte{
+			"services/A/values/env-specific": nil,
+			"folder/name.tmpl":               nil,
+			"values/.tmpl/test":              nil,
+			"values/name.tmpl":               nil,
+			"values/env1/file1.yaml": []byte(`
+k1: v1
+k2: v1
+k3:
+  k31: v1
+arr:
+  - v1
+  - v11
+`),
+			"values/env1/file2.yaml": []byte(`
+k2: v2
+k22: v22
+k3:
+  k31: v2
+arr:
+  - v2
+`),
+			"values/env1/coco.yaml": []byte(`
+type: environment
+name: name1
+values: 
+  - file1.yaml
+  - file2.yaml
+`),
+		},
+		wantFiles: map[string][]byte{
+			"name1": []byte(`
+k1: v1
+k2: v2
+k22: v22
+k3:
+  k31: v2
+arr:
+  - v2
+`),
+		},
+		wantErr: nil,
+	},
+	{
 		title:          "working general example with different values directories",
 		includeFilters: []string{"${BASEPATH}/values/", "${BASEPATH}/values2/"},
 		excludeFilters: []string{".tmpl"},

--- a/cmd/coco/generate/renderTemplate.go
+++ b/cmd/coco/generate/renderTemplate.go
@@ -83,7 +83,7 @@ func (p parser) execute(data interface{}) ([]byte, error) {
 }
 
 func mergeValues(valueFiles []string) (res yamlfile.Yaml, err error) {
-	res, err = yamlfile.New([]byte{})
+	res, err = yamlfile.New([]byte{}, yamlfile.SetArrayMergePolicy(yamlfile.Strict))
 	if err != nil {
 		err = fmt.Errorf("failed to create combined values file: %w", err)
 		return

--- a/pkg/yamlfile/settings.go
+++ b/pkg/yamlfile/settings.go
@@ -1,0 +1,36 @@
+package yamlfile
+
+type UpdateSettingsFunc func(*settings)
+
+type settings struct {
+	arrayMergePolicy ArrayMergePolicy
+}
+
+func newSettings(opts ...UpdateSettingsFunc) *settings {
+	s := settings{
+		arrayMergePolicy: Standard,
+	}
+	for i := range opts {
+		opts[i](&s)
+	}
+	return &s
+}
+
+func (s settings) Copy() settings {
+	return settings{
+		s.arrayMergePolicy,
+	}
+}
+
+func SetArrayMergePolicy(policy ArrayMergePolicy) UpdateSettingsFunc {
+	return func(s *settings) {
+		s.arrayMergePolicy = policy
+	}
+}
+
+type ArrayMergePolicy uint8
+
+const (
+	Standard ArrayMergePolicy = 1 << iota
+	Strict
+)

--- a/pkg/yamlfile/subnode.go
+++ b/pkg/yamlfile/subnode.go
@@ -19,7 +19,8 @@ func (y Yaml) SelectSubElement(keys []string) (Yaml, error) {
 	if err != nil {
 		return Yaml{}, err
 	}
-	return Yaml{subNode}, nil
+	s := y.settings.Copy()
+	return Yaml{subNode, &s}, nil
 }
 
 func (y *Yaml) Insert(parentKeys []string, subelement interface{}) ([]Warning, error) {


### PR DESCRIPTION
Currently, environment value files are merged with the default yamlfile merge behaviour. For arrays this leads to unexpected behaviour, since arrays are merged as best-effort elementwise.

The expected behaviour is that arrays for environment value files are merged by overwriting the target array with the source array.

This PR implements this change