### PR TITLE
fix(reconcile): made cross repo more robust

### DIFF
--- a/cmd/coco/commands/reconcile.go
+++ b/cmd/coco/commands/reconcile.go
@@ -82,12 +82,14 @@ func newReconcile() *cobra.Command {
 	c.PersistentFlags().StringVarP(&sourceBranch, "source", "s", "", "The source branch to reconcile from.")
 	failOnError(c.MarkPersistentFlagRequired("source"), "reconcile")
 
-	c.PersistentFlags().StringVar(&sourceRemote, "source-remote", "origin", "The remote for the source branch.")
+	c.PersistentFlags().StringVar(&sourceRemote, "source-remote", "origin", `The URL for the source branch.
+	Can be left out incase the source and target branches are in the same repository.`)
 
 	c.PersistentFlags().StringVarP(&targetBranch, "target", "t", "", "The target branch to reconcile to.")
 	failOnError(c.MarkPersistentFlagRequired("target"), "reconcile")
 
-	c.PersistentFlags().StringVar(&targetRemote, "target-remote", "origin", "The remote for the target branch.")
+	c.PersistentFlags().StringVar(&targetRemote, "target-remote", "origin", `The URL for the target branch.
+	Can be left out incase the source and target branches are in the same repository.`)
 
 	c.PersistentFlags().StringVar(&repositoryName, "repo", "", "The name of the TARGET github repository.")
 	failOnError(

--- a/cmd/coco/commands/reconcile.go
+++ b/cmd/coco/commands/reconcile.go
@@ -79,7 +79,7 @@ func newReconcile() *cobra.Command {
 		},
 	}
 
-	c.PersistentFlags().StringVarP(&sourceBranch, "source", "s", "", "The souce branch to reconcile from.")
+	c.PersistentFlags().StringVarP(&sourceBranch, "source", "s", "", "The source branch to reconcile from.")
 	failOnError(c.MarkPersistentFlagRequired("source"), "reconcile")
 
 	c.PersistentFlags().StringVar(&sourceRemote, "source-remote", "origin", "The remote for the source branch.")
@@ -89,15 +89,15 @@ func newReconcile() *cobra.Command {
 
 	c.PersistentFlags().StringVar(&targetRemote, "target-remote", "origin", "The remote for the target branch.")
 
-	c.PersistentFlags().StringVar(&repositoryName, "repo", "", "The name of the gihtub repository.")
+	c.PersistentFlags().StringVar(&repositoryName, "repo", "", "The name of the TARGET github repository.")
 	failOnError(
 		c.PersistentFlags().MarkDeprecated("repo", `please use "repository" flag instead.`),
 		"reconcile",
 	)
-	c.PersistentFlags().StringVar(&repositoryName, "repository", "", "The name of the gihtub repository.")
+	c.PersistentFlags().StringVar(&repositoryName, "repository", "", "The name of the TARGET github repository.")
 	failOnError(c.MarkPersistentFlagRequired("repository"), "reconcile")
 
-	c.PersistentFlags().StringVar(&owner, "owner", "", "The account owner of the github repository.")
+	c.PersistentFlags().StringVar(&owner, "owner", "", "The account owner of the TARGET github repository.")
 	failOnError(c.MarkPersistentFlagRequired("owner"), "reconcile")
 
 	c.Flags().BoolVar(

--- a/cmd/coco/reconcile/reconcile.go
+++ b/cmd/coco/reconcile/reconcile.go
@@ -184,7 +184,7 @@ func copyBranch(targetRepo *git.Repository, sourceBranch BranchConfig, remoteNam
 		return err
 	}
 	ref := plumbing.NewHashReference(replicaBranchName, sourceRef.Hash())
-	if err = targetRepo.Storer.SetReference(ref); err != nil {
+	if err := targetRepo.Storer.SetReference(ref); err != nil {
 		return err
 	}
 	err = gitPush(targetRepo, &git.PushOptions{

--- a/cmd/coco/reconcile/reconcile.go
+++ b/cmd/coco/reconcile/reconcile.go
@@ -81,7 +81,7 @@ func New(
 
 func (r *Client) Reconcile(force bool) error {
 	if r.target.Remote != r.source.Remote {
-		//change source.name to remote-replica/source.Name and continue
+		// change source.name to remote-replica/source.Name and continue
 		r.source.Name = fmt.Sprintf("remote-replica/%s", r.source.Name)
 	}
 	return r.merge(force)
@@ -184,7 +184,7 @@ func copyBranch(targetRepo *git.Repository, sourceBranch BranchConfig, remoteNam
 		return err
 	}
 	ref := plumbing.NewHashReference(replicaBranchName, sourceRef.Hash())
-	if err := targetRepo.Storer.SetReference(ref); err != nil {
+	if err = targetRepo.Storer.SetReference(ref); err != nil {
 		return err
 	}
 	err = gitPush(targetRepo, &git.PushOptions{

--- a/cmd/coco/reconcile/reconcile.go
+++ b/cmd/coco/reconcile/reconcile.go
@@ -184,7 +184,8 @@ func copyBranch(targetRepo *git.Repository, sourceBranch BranchConfig, remoteNam
 		return err
 	}
 	ref := plumbing.NewHashReference(replicaBranchName, sourceRef.Hash())
-	if err := targetRepo.Storer.SetReference(ref); err != nil {
+	err = targetRepo.Storer.SetReference(ref)
+	if err != nil {
 		return err
 	}
 	err = gitPush(targetRepo, &git.PushOptions{


### PR DESCRIPTION
In the scenario where we are reconciling between repositories, we now automatically raise a PR in the target repository with the replicated source branch. Hence improving the UX.
In-order to achieve the above, we have to make sure that the ownerName and repositoryName provided in the command is that of the target repository, so that after replicating the source to the target repository, we can reconcile between the source replica and target branch in the target branch repository.